### PR TITLE
Rework Formulas class

### DIFF
--- a/assyst/crystals.py
+++ b/assyst/crystals.py
@@ -59,8 +59,8 @@ class Formulas(Sequence):
 
     @classmethod
     def unary_range(cls, element: str, *range_args) -> Self:
-        '''Creates '''
-        return cls(tuple({element: i} for i in range(*range_args) if i > 0))
+        '''Creates unary formulas with number of atoms as given by then builtin `range`.'''
+        return cls(tuple({element: i} for i in range(*range_args)))
 
     def __add__(self, other: Self) -> Self:
         '''Extend underlying list of stoichiometries.'''
@@ -157,6 +157,11 @@ def sample_space_groups(
             raise ValueError('invalid value tolerance={tolerance}!')
 
     for stoich in (bar := tqdm(formulas)):
+        # pyxtal never returns structures when one element with zero atoms is present, so filter here first for
+        # robustness
+        stoich = {e: n for e, n in stoich.items() if n > 0}
+        if len(stoich) == 0:
+            continue
         elements, num_atoms = zip(*stoich.items())
         if not min_atoms <= sum(num_atoms) <= max_atoms:
             continue

--- a/assyst/crystals.py
+++ b/assyst/crystals.py
@@ -100,6 +100,13 @@ class Formulas(Sequence):
     def __len__(self) -> int:
         return len(self.atoms)
 
+    def trim(self, min_atoms: int = 1, max_atoms: int | None = None) -> Self:
+        '''Returns a copy of itself with formulas with lesser or more atoms than given limits removed.'''
+        if max_atoms is not None:
+            return type(self)(tuple(f for f in self if min_atoms <= sum(f.values()) <= max_atoms))
+        else:
+            return type(self)(tuple(f for f in self if min_atoms <= sum(f.values())))
+
 
 def sample_space_groups(
         formulas: Formulas | Iterable[dict[str, int]],
@@ -108,7 +115,7 @@ def sample_space_groups(
         max_atoms: int = 10,
         max_structures: int | None = None,
         dim: Literal[0, 1, 2, 3] = 3,
-        tolerance: Literal['metallic', 'atomic', 'molecular', 'vdW'] | dict = 'metallic',
+        tolerance: Literal['metallic', 'atomic', 'molecular', 'vdW'] | DistanceFilter | dict = 'metallic',
 ) -> Iterator[Atoms]:
     '''
     Create symmetric random structures.

--- a/assyst/crystals.py
+++ b/assyst/crystals.py
@@ -27,24 +27,24 @@ class Formulas(Sequence):
 
     >>> el_manual = Formulas(({'Cu': 1}, {'Cu': 2}))
 
-    :meth:`.unary_range` is a helper class method that initializes `Formulas` for a single element and takes the same
+    :meth:`.range` is a helper class method that initializes `Formulas` for a single element and takes the same
     arguments as the builtin `range`, except that it skips the zero.
 
-    >>> el = Formulas.unary_range('Cu', 3)
+    >>> el = Formulas.range('Cu', 3)
     Formulas(atoms=({'Cu': 1}, {'Cu': 2}))
     >>> el == el_manual
     True
 
     Addition is overloaded to the addition of the underlying tuples.
 
-    >>> Formulas.unary_range('Cu', 1, 5) == Formulas.unary_range('Cu', 1, 3) + Formulas.unary_range('Cu', 3, 5)
+    >>> Formulas.range('Cu', 1, 5) == Formulas.range('Cu', 1, 3) + Formulas.range('Cu', 3, 5)
 
     The bitwise or operation is akin to the inner product
 
-    >>> Formulas.unary_range('Cu', 3) | Formulas.unary_range('Ag', 3)
+    >>> Formulas.range('Cu', 3) | Formulas.range('Ag', 3)
     Formulas(atoms=({'Cu': 1, 'Ag': 1}, {'Cu': 2, 'Ag': 2}))
 
-    >>> Formulas.unary_range('Cu', 3) * Formulas.unary_range('Ag', 3)
+    >>> Formulas.range('Cu', 3) * Formulas.range('Ag', 3)
     Formulas(atoms=({'Cu': 1, 'Ag': 1}, {'Cu': 2, 'Ag': 1}, {'Cu': 1, 'Ag': 2}, {'Cu': 2, 'Ag': 2}))
     '''
     atoms: tuple[dict[str, int], ...]
@@ -58,9 +58,17 @@ class Formulas(Sequence):
         return e
 
     @classmethod
-    def unary_range(cls, element: str, *range_args) -> Self:
-        '''Creates unary formulas with number of atoms as given by then builtin `range`.'''
-        return cls(tuple({element: i} for i in range(*range_args)))
+    def range(cls, elements: str | Iterable[str], *range_args) -> Self:
+        '''Creates formulas with number of atoms as given by the builtin `range`.
+
+        Multiple elements are combined as the outer product.'''
+        if isinstance(elements, str):
+            return cls(tuple({elements: i} for i in range(*range_args)))
+        formulas = [cls.range(e, *range_args) for e in elements]
+        total = formulas[0]
+        for f in formulas[1:]:
+            total *= f
+        return total
 
     def __add__(self, other: Self) -> Self:
         '''Extend underlying list of stoichiometries.'''

--- a/tests/test_crystal.py
+++ b/tests/test_crystal.py
@@ -7,17 +7,26 @@ from assyst.crystals import Formulas, sample_space_groups
 
 class TestFormulas(unittest.TestCase):
 
-    def test_unary_range(self):
-        f = Formulas.unary_range("Cu", 1, 4)
-        self.assertEqual(len(f), 3, msg="Length of unary_range('Cu', 1, 4) should be 3")
+    def test_range(self):
+        f = Formulas.range("Cu", 1, 4)
+        self.assertEqual(len(f), 3, msg="Length of range('Cu', 1, 4) should be 3")
         self.assertEqual(f[0], {"Cu": 1}, msg="First element should be {'Cu': 1}")
         self.assertEqual(f[1], {"Cu": 2}, msg="Second element should be {'Cu': 2}")
         self.assertEqual(f[2], {"Cu": 3}, msg="Third element should be {'Cu': 3}")
         self.assertEqual(f.elements, {"Cu"}, msg="Elements should be {'Cu'}")
 
+    def test_binary_range(self):
+        f = Formulas.range(("Cu", "Ag"), 1, 3)
+        self.assertEqual(f.elements, {"Cu", "Ag"}, msg="Elements should contain all given elements: {'Cu', 'Ag'}")
+        self.assertEqual(
+            Formulas.range(("Cu", "Ag"), 1, 3),
+            Formulas.range("Cu", 1, 3) * Formulas.range("Ag", 1, 3),
+            msg="range called with 2 elements should match outer product"
+        )
+
     def test_addition(self):
-        f1 = Formulas.unary_range("Cu", 1, 3)
-        f2 = Formulas.unary_range("Cu", 3, 5)
+        f1 = Formulas.range("Cu", 1, 3)
+        f2 = Formulas.range("Cu", 3, 5)
         combined = f1 + f2
         self.assertIsInstance(combined, Formulas, msg="Result of addition should be a Formulas instance")
         self.assertEqual(len(combined), 4, msg="Combined length should be 4")
@@ -25,8 +34,8 @@ class TestFormulas(unittest.TestCase):
         self.assertEqual(combined[-1], {"Cu": 4}, msg="Last element after addition should be {'Cu': 4}")
 
     def test_or_operator(self):
-        cu = Formulas.unary_range("Cu", 1, 3)
-        ag = Formulas.unary_range("Ag", 1, 3)
+        cu = Formulas.range("Cu", 1, 3)
+        ag = Formulas.range("Ag", 1, 3)
         result = cu | ag
         self.assertIsInstance(result, Formulas, msg="Result of | operation should be a Formulas instance")
         self.assertIn({"Cu": 1, "Ag": 1}, result, msg="Result should contain {'Cu': 1, 'Ag': 1}")
@@ -36,8 +45,8 @@ class TestFormulas(unittest.TestCase):
             _ = cu | cu
 
     def test_mul_operator(self):
-        cu = Formulas.unary_range("Cu", 1, 3)
-        ag = Formulas.unary_range("Ag", 1, 3)
+        cu = Formulas.range("Cu", 1, 3)
+        ag = Formulas.range("Ag", 1, 3)
         result = cu * ag
         expected = [
             {"Cu": 1, "Ag": 1},
@@ -53,10 +62,23 @@ class TestFormulas(unittest.TestCase):
             _ = cu * cu
 
     def test_sequence_protocol(self):
-        f = Formulas.unary_range("Cu", 1, 3)
+        f = Formulas.range("Cu", 1, 3)
         self.assertIsInstance(f[0], dict, msg="Items in Formulas should be dicts")
-        self.assertEqual(len(f), 2, msg="Length of unary_range('Cu', 1, 3) should be 2")
+        self.assertEqual(len(f), 2, msg="Length of range('Cu', 1, 3) should be 2")
 
+    def test_trim(self):
+        f = Formulas.range(("Cu", "Ag"), 10)
+        for fi in f.trim():
+            self.assertNotEqual(sum(fi.values()), 0,
+                                msg="Trim called with no arguments should remove zero sizes formulas.")
+
+        for fi in f.trim(min_atoms=3):
+            self.assertGreaterEqual(sum(fi.values()), 3,
+                                    msg="min_atoms should remove all formulas with less atoms.")
+
+        for fi in f.trim(max_atoms=8):
+            self.assertLessEqual(sum(fi.values()), 8,
+                                 msg="max_atoms should remove all formulas with more atoms.")
 
 def make_mock_atoms():
     atoms = MagicMock(spec=Atoms)
@@ -75,7 +97,7 @@ class TestSampleSpaceGroups(unittest.TestCase):
     def test_max_structures(self, mock_pyxtal):
         mock_atoms, mock_pyxtal.side_effect = make_pyxtal_mock_side_effect(5)
 
-        f = Formulas.unary_range("Cu", 1, 3)
+        f = Formulas.range("Cu", 1, 3)
         results = list(sample_space_groups(f, max_structures=3))
 
         self.assertEqual(len(results), 3, msg="Should not generate more than max_structures=3")
@@ -85,7 +107,7 @@ class TestSampleSpaceGroups(unittest.TestCase):
         mock_atoms, mock_pyxtal.side_effect = make_pyxtal_mock_side_effect()
 
         # Define 3 compositions: Cu1, Cu2, Cu3
-        formulas = Formulas.unary_range("Cu", 1, 4)  # 3 compositions
+        formulas = Formulas.range("Cu", 1, 4)  # 3 compositions
 
         results = list(sample_space_groups(formulas, max_structures=10))
 
@@ -105,13 +127,13 @@ class TestSampleSpaceGroups(unittest.TestCase):
                     # actual called includes spacegroups that we did not include in the mock
                     actual[1:], expected,
                     msg=f"Expected pyxtal to be called with atom counts {expected[1]}, got {actual[1]}"
-        )
+            )
 
     @patch("assyst.crystals.pyxtal")
     def test_min_atoms(self, mock_pyxtal):
         mock_atoms, mock_pyxtal.side_effect = make_pyxtal_mock_side_effect()
 
-        formulas = Formulas.unary_range("Cu", 1, 10)
+        formulas = Formulas.range("Cu", 1, 10)
         results = list(sample_space_groups(formulas, min_atoms=5))
 
         with self.subTest("unary"):
@@ -122,8 +144,8 @@ class TestSampleSpaceGroups(unittest.TestCase):
 
         mock_pyxtal.reset_mock()
 
-        formulas = Formulas.unary_range("Cu", 10) * Formulas.unary_range("Ag", 10)
-        results = list(sample_space_groups(formulas, min_atoms=5))
+        formulas = Formulas.range("Cu", 10) * Formulas.range("Ag", 10)
+        list(sample_space_groups(formulas, min_atoms=5))
 
         with self.subTest("binary"):
             for call in mock_pyxtal.call_args_list:
@@ -135,8 +157,8 @@ class TestSampleSpaceGroups(unittest.TestCase):
     def test_max_atoms(self, mock_pyxtal):
         mock_atoms, mock_pyxtal.side_effect = make_pyxtal_mock_side_effect()
 
-        formulas = Formulas.unary_range("Cu", 1, 10)
-        results = list(sample_space_groups(formulas, max_atoms=5))
+        formulas = Formulas.range("Cu", 1, 10)
+        list(sample_space_groups(formulas, max_atoms=5))
 
         with self.subTest("unary"):
             for call in mock_pyxtal.call_args_list:
@@ -146,8 +168,8 @@ class TestSampleSpaceGroups(unittest.TestCase):
 
         mock_pyxtal.reset_mock()
 
-        formulas = Formulas.unary_range("Cu", 10) * Formulas.unary_range("Ag", 10)
-        results = list(sample_space_groups(formulas, max_atoms=5))
+        formulas = Formulas.range("Cu", 10) * Formulas.range("Ag", 10)
+        list(sample_space_groups(formulas, max_atoms=5))
 
         with self.subTest("binary"):
             for call in mock_pyxtal.call_args_list:


### PR DESCRIPTION
Add `trim` method to remove formulas by total number of atoms.
Generalize `unary_range` to `range` allowing more elements and include zero by default.