### PR TITLE
Increase coverage for filters.py

### DIFF
--- a/tests/filter/test_aspect.py
+++ b/tests/filter/test_aspect.py
@@ -1,0 +1,19 @@
+import unittest
+from ase import Atoms
+from assyst.filters import AspectFilter
+
+class TestAspectFilter(unittest.TestCase):
+    def test_aspect_filter(self):
+        filter = AspectFilter(maximum_aspect_ratio=2.0)
+
+        # Aspect ratio = 1.0
+        structure1 = Atoms('Cu', cell=[2, 2, 2], pbc=True)
+        self.assertTrue(filter(structure1))
+
+        # Aspect ratio = 2.0
+        structure2 = Atoms('Cu', cell=[2, 2, 4], pbc=True)
+        self.assertTrue(filter(structure2))
+
+        # Aspect ratio = 2.5
+        structure3 = Atoms('Cu', cell=[2, 2, 5], pbc=True)
+        self.assertFalse(filter(structure3))

--- a/tests/filter/test_calculator.py
+++ b/tests/filter/test_calculator.py
@@ -1,0 +1,66 @@
+import unittest
+import numpy as np
+from ase import Atoms
+from ase.calculators.singlepoint import SinglePointCalculator
+from assyst.filters import EnergyFilter, ForceFilter, CalculatorFilter
+
+class MockCalculatorFilter(CalculatorFilter):
+    def __call__(self, structure: Atoms) -> bool:
+        return self._check(structure)
+
+class TestCalculatorFilters(unittest.TestCase):
+    def test_calculator_filter_check(self):
+        filter = MockCalculatorFilter(missing='error')
+
+        # No calculator
+        structure = Atoms('Cu')
+        with self.assertRaises(ValueError):
+            filter._check(structure)
+
+        # Wrong calculator
+        structure.calc = "dummy"
+        with self.assertRaises(ValueError):
+            filter._check(structure)
+
+        # Correct calculator
+        structure.calc = SinglePointCalculator(structure, energy=0.0, forces=np.zeros((1, 3)))
+        self.assertTrue(filter._check(structure))
+
+        # Missing ignore
+        filter = MockCalculatorFilter(missing='ignore')
+        structure = Atoms('Cu')
+        self.assertFalse(filter(structure))
+
+    def test_energy_filter(self):
+        # Test with no calculator
+        filter = EnergyFilter(max_energy=1.0, missing='ignore')
+        structure = Atoms('Cu')
+        self.assertTrue(filter(structure)) # Should pass if _check is false
+
+        filter = EnergyFilter(max_energy=1.0)
+        structure = Atoms('Cu')
+        structure.calc = SinglePointCalculator(structure, energy=2.0)
+        self.assertFalse(filter(structure)) # energy 2.0 > 1.0
+
+        structure.calc = SinglePointCalculator(structure, energy=0.5)
+        self.assertTrue(filter(structure)) # energy 0.5 < 1.0
+
+        filter = EnergyFilter(min_energy=0.0, max_energy=1.0)
+        structure.calc = SinglePointCalculator(structure, energy=-0.5)
+        self.assertFalse(filter(structure)) # energy -0.5 < 0.0
+
+    def test_force_filter(self):
+        # Test with no calculator
+        filter = ForceFilter(max_force=1.0, missing='ignore')
+        structure = Atoms('Cu')
+        self.assertTrue(filter(structure)) # Should pass if _check is false
+
+        filter = ForceFilter(max_force=1.0)
+        structure = Atoms('Cu')
+        forces = np.array([[1.1, 0.0, 0.0]])
+        structure.calc = SinglePointCalculator(structure, forces=forces)
+        self.assertFalse(filter(structure)) # force 1.1 > 1.0
+
+        forces = np.array([[0.5, 0.0, 0.0]])
+        structure.calc = SinglePointCalculator(structure, forces=forces)
+        self.assertTrue(filter(structure)) # force 0.5 < 1.0

--- a/tests/filter/test_composition.py
+++ b/tests/filter/test_composition.py
@@ -1,0 +1,40 @@
+import unittest
+from ase import Atoms
+from assyst.filters import AndFilter, OrFilter, FilterBase
+
+class MockFilter(FilterBase):
+    def __init__(self, value):
+        self.value = value
+    def __call__(self, structure: Atoms) -> bool:
+        return self.value
+
+class TestComposition(unittest.TestCase):
+    def test_and_filter(self):
+        structure = Atoms()
+        # True and True
+        self.assertTrue(AndFilter(MockFilter(True), MockFilter(True))(structure))
+        # True and False
+        self.assertFalse(AndFilter(MockFilter(True), MockFilter(False))(structure))
+        # False and True
+        self.assertFalse(AndFilter(MockFilter(False), MockFilter(True))(structure))
+        # False and False
+        self.assertFalse(AndFilter(MockFilter(False), MockFilter(False))(structure))
+
+    def test_or_filter(self):
+        structure = Atoms()
+        self.assertTrue(OrFilter(MockFilter(True), MockFilter(True))(structure))
+        self.assertTrue(OrFilter(MockFilter(True), MockFilter(False))(structure))
+        self.assertTrue(OrFilter(MockFilter(False), MockFilter(True))(structure))
+        self.assertFalse(OrFilter(MockFilter(False), MockFilter(False))(structure))
+
+    def test_and_operator(self):
+        structure = Atoms()
+        and_filter = MockFilter(True) & MockFilter(False)
+        self.assertIsInstance(and_filter, AndFilter)
+        self.assertFalse(and_filter(structure))
+
+    def test_or_operator(self):
+        structure = Atoms()
+        or_filter = MockFilter(True) | MockFilter(False)
+        self.assertIsInstance(or_filter, OrFilter)
+        self.assertTrue(or_filter(structure))

--- a/tests/filter/test_distance.py
+++ b/tests/filter/test_distance.py
@@ -2,6 +2,8 @@ import unittest
 import numpy as np
 from ase import Atoms
 from assyst.filters import DistanceFilter
+from pyxtal.tolerance import Tol_matrix
+from ase.data import atomic_numbers
 
 class TestDistanceFilter(unittest.TestCase):
     def test_element_wise_dist(self):
@@ -76,6 +78,23 @@ class TestDistanceFilter(unittest.TestCase):
         self.assertTrue(filter(structure), msg="minimal image d=0.5 > 2*0.1, so True")
         filter = DistanceFilter({'Cu': 0.3})
         self.assertFalse(filter(structure), msg="minimal image d=0.5 < 2*0.3")
+
+    def test_to_tol_matrix(self):
+        """to_tol_matrix returns a correct Tol_matrix object."""
+        radii = {'Cu': 1.3, 'Ag': 1.5}
+        filter = DistanceFilter(radii)
+        tol_matrix = filter.to_tol_matrix()
+
+        self.assertIsInstance(tol_matrix, Tol_matrix)
+
+        # Check a few values
+        cu_cu = radii['Cu'] + radii['Cu']
+        ag_ag = radii['Ag'] + radii['Ag']
+        cu_ag = radii['Cu'] + radii['Ag']
+
+        self.assertEqual(tol_matrix.get_tol(atomic_numbers['Cu'], atomic_numbers['Cu']), cu_cu)
+        self.assertEqual(tol_matrix.get_tol(atomic_numbers['Ag'], atomic_numbers['Ag']), ag_ag)
+        self.assertEqual(tol_matrix.get_tol(atomic_numbers['Cu'], atomic_numbers['Ag']), cu_ag)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/filter/test_volume.py
+++ b/tests/filter/test_volume.py
@@ -1,0 +1,19 @@
+import unittest
+from ase import Atoms
+from assyst.filters import VolumeFilter
+
+class TestVolumeFilter(unittest.TestCase):
+    def test_volume_filter(self):
+        filter = VolumeFilter(maximum_volume_per_atom=20.0)
+
+        # Volume per atom = 8.0
+        structure1 = Atoms('Cu', cell=[2, 2, 2], pbc=True)
+        self.assertTrue(filter(structure1))
+
+        # Volume per atom = 20.0
+        structure2 = Atoms('Cu2', cell=[4, 5, 2], pbc=True)
+        self.assertTrue(filter(structure2))
+
+        # Volume per atom = 20.0001
+        structure3 = Atoms('Cu', cell=[2, 2, 5.0001], pbc=True)
+        self.assertFalse(filter(structure3))


### PR DESCRIPTION
Add tests for uncovered lines in the filters.py submodule.

- Add tests for AndFilter and OrFilter.
- Add test for DistanceFilter.to_tol_matrix.
- Add tests for AspectFilter.
- Add tests for VolumeFilter.
- Add tests for CalculatorFilter, EnergyFilter, and ForceFilter.

This increases the test coverage of filters.py to 97%.