### PR TITLE
Add error handling tests for CalculatorFilter subclasses

### DIFF
--- a/tests/filter/test_calculator.py
+++ b/tests/filter/test_calculator.py
@@ -64,3 +64,29 @@ class TestCalculatorFilters(unittest.TestCase):
         forces = np.array([[0.5, 0.0, 0.0]])
         structure.calc = SinglePointCalculator(structure, forces=forces)
         self.assertTrue(filter(structure)) # force 0.5 < 1.0
+
+    def test_energy_filter_error_handling(self):
+        energy_filter = EnergyFilter(max_energy=1.0, missing='error')
+        structure = Atoms('Cu')
+
+        # Test missing calculator
+        with self.assertRaises(ValueError):
+            energy_filter(structure)
+
+        # Test invalid calculator type
+        structure.calc = "dummy"
+        with self.assertRaises(ValueError):
+            energy_filter(structure)
+
+    def test_force_filter_error_handling(self):
+        force_filter = ForceFilter(max_force=1.0, missing='error')
+        structure = Atoms('Cu')
+
+        # Test missing calculator
+        with self.assertRaises(ValueError):
+            force_filter(structure)
+
+        # Test invalid calculator type
+        structure.calc = "dummy"
+        with self.assertRaises(ValueError):
+            force_filter(structure)


### PR DESCRIPTION
Add error handling tests for CalculatorFilter subclasses

Introduced unit tests to verify that EnergyFilter and ForceFilter correctly
raise ValueError when configured with missing='error' and encountered with
structures lacking a calculator or having an invalid calculator type.
These tests ensure robustness in filtering logic when structure metadata is
incomplete or incorrect.

The tests cover:
- Missing calculator (structure.calc is None)
- Invalid calculator type (structure.calc is not a SinglePointCalculator)

---
*PR created automatically by Jules for task [5280523352852809531](https://jules.google.com/task/5280523352852809531) started by @pmrv*