### PR TITLE
docs: make API Reference its own foldable sidebar section

### DIFF
--- a/docs/assyst.rst
+++ b/docs/assyst.rst
@@ -1,5 +1,5 @@
-API assyst package
-==============
+API Reference
+=============
 
 Submodules
 ----------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,4 +65,10 @@ The final step is labelling the structures with high quality DFT, which is outsi
    overview
    metadata
    notebooks
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+   :caption: API Reference:
+
    assyst


### PR DESCRIPTION
Split the single toctree in index.rst into two separate captioned toctrees. Furo renders each captioned toctree as a collapsible sidebar section, so the API Reference is now its own foldable entry at the bottom of the navigation.

Also fixes the ungrammatical heading in assyst.rst.

Closes #84

Generated with [Claude Code](https://claude.ai/code)