### PR TITLE
docs: add source button to API docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,6 +22,7 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.napoleon',
     'sphinx.ext.intersphinx',
+    'sphinx.ext.viewcode',
     'myst_nb',
 ]
 


### PR DESCRIPTION
Add `sphinx.ext.viewcode` extension to enable source buttons in the API documentation, allowing readers to navigate directly to the underlying source code.

Closes #92

Generated with [Claude Code](https://claude.ai/code)