### PR TITLE
fix: skip structures with no neighbors in distance_histogram

### DIFF
--- a/assyst/plot.py
+++ b/assyst/plot.py
@@ -181,7 +181,12 @@ def distance_histogram(
     else:
         reduce_func = _preset.get(reduce, reduce)
         def extractor(s):
-            return [reduce_func(neighbor_list("d", struct, float(rmax))) for struct in s]
+            distances = []
+            for struct in s:
+                d = neighbor_list("d", struct, float(rmax))
+                if len(d) > 0:
+                    distances.append(reduce_func(d))
+            return distances
         ylabel = r"#$\,$Structures"
 
     return _plot_histogram(structures, extractor, xlabel, ylabel, **kwargs)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -83,6 +83,14 @@ class TestPlotFunctions(unittest.TestCase):
 
     @unittest.skipIf(matscipy is None, "matscipy not installed")
     @patch('matplotlib.pyplot.hist')
+    def test_distance_histogram_no_neighbors(self, mock_hist):
+        # Single-atom structure has no neighbors; should not raise
+        no_neighbors = Atoms('H', positions=[[0, 0, 0]], cell=[10, 10, 10])
+        distance_histogram([no_neighbors] + self.structures, reduce="min")
+        distance_histogram([no_neighbors] + self.structures, reduce="mean")
+
+    @unittest.skipIf(matscipy is None, "matscipy not installed")
+    @patch('matplotlib.pyplot.hist')
     def test_radial_distribution(self, mock_hist):
         radial_distribution(self.structures)
         mock_hist.assert_called_once()


### PR DESCRIPTION
Structures with no neighbors in the given rmax interval caused np.min/np.mean to raise a ValueError on an empty array. Now such structures are silently skipped.

Fixes #96

Generated with [Claude Code](https://claude.ai/code)