### PR TITLE
fix: rename structure to structures in relax() signature

### DIFF
--- a/assyst/relax.py
+++ b/assyst/relax.py
@@ -106,7 +106,7 @@ class FullRelax(Relax):
 def relax(
     settings: Relax,
     calculator: AseCalculatorConfig | Calculator,
-    structure: Iterable[Atoms],
+    structures: Iterable[Atoms],
 ) -> Iterator[Atoms]:
     """Relax structures according the given relaxation settings.
 
@@ -115,12 +115,12 @@ def relax(
     Args:
         settings (:class:`.Relax`): the kind of relaxation to perform (position, volume, etc.)
         calculator (:class:`.AseCalculatorConfig` or :class:`ase.calculators.calculator.Calculator`): the energy/force engine to use
-        structure (:class:`collections.abc.Iterable` of :class:`ase.Atoms`): the structures to minimize
+        structures (:class:`collections.abc.Iterable` of :class:`ase.Atoms`): the structures to minimize
 
     Yields:
         :class:`ase.Atoms`: the corresponding relaxed configuration to each input structure
     """
-    for s in structure:
+    for s in structures:
         s = s.copy()
         if isinstance(calculator, AseCalculatorConfig):
             s.calc = calculator.get_calculator()

--- a/docs/custom_relaxer.rst
+++ b/docs/custom_relaxer.rst
@@ -134,7 +134,7 @@ Once defined, ``MyEngineRelax`` is a drop-in replacement anywhere
         assyst_relax(
             settings=settings,
             calculator=None,   # calculator is unused by MyEngineRelax.relax
-            structure=my_structures,
+            structures=my_structures,
         )
     )
 


### PR DESCRIPTION
Fixes the singular/plural inconsistency: the `structure` parameter in `relax()` accepted `Iterable[Atoms]` but was named in the singular, unlike the plural `structures` used in `apply_perturbations` and elsewhere.

Also updates the keyword argument in the `docs/custom_relaxer.rst` example.

Closes #109

Generated with [Claude Code](https://claude.ai/code)