### PR TITLE
fix: correct notebook paths in sphinx docs

### DIFF
--- a/docs/notebooks.rst
+++ b/docs/notebooks.rst
@@ -5,8 +5,7 @@ Notebooks
    :maxdepth: 1
    :glob:
 
-   notebooks/Crystals.ipynb
+   notebooks/Quickstart/Crystals.ipynb
    notebooks/SimpleUnary.ipynb
    notebooks/PlotGallery.ipynb
-   notebooks/BinarySampling.ipynb
    notebooks/Lineage.ipynb


### PR DESCRIPTION
Fix two broken notebook references in `docs/notebooks.rst`:
- Update `Crystals.ipynb` path to `notebooks/Quickstart/Crystals.ipynb` (file was moved to a subdirectory)
- Remove `BinarySampling.ipynb` reference (file does not exist in the repo)

Closes #115

Generated with [Claude Code](https://claude.ai/code)