### PR TITLE
feat: add Python 3.14 support

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
         os: ["ubuntu-latest"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ authors = [
     { name="Marvin Poul", email="pmrv@posteo.de" },
 ]
 readme = "README.md"
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.11,<3.15"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",


### PR DESCRIPTION
## Summary

- Bump `requires-python` upper bound from `<3.14` → `<3.15` in `pyproject.toml`
- Add `"3.14"` to the CI test matrix in `unittest.yml`

## Scouting notes

No source changes needed. The codebase was checked for all known Python 3.14 breaking changes:

- No removed stdlib modules used (`distutils`, `cgi`, `aifc`, etc.)
- No deprecated `typing` aliases that were removed (e.g. `ByteString`)
- No deprecated `ast` node types
- All `typing` imports (`Self`, `Iterable`, `Callable`, `Iterator`, `Union`, `Literal`) remain valid in 3.14
- Modern built-in generics (`dict[str, T]`, `X | Y`) already used throughout

All pinned dependencies support Python 3.14:
- `pyxtal>=1,<1.2.0` (1.1.3 declares `Requires-Python: >=3.9`)
- `ase`, `numpy`, `pandas`, `matplotlib`, `seaborn`, `pyiron_snippets` — no conflicting upper bounds

## Test plan

- [ ] CI passes on Python 3.14 runner after merging

https://claude.ai/code/session_01Qb2goUGeNoTjGbmi26fQxo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qb2goUGeNoTjGbmi26fQxo)_