### PR TITLE
docs: fix typos and grammar across docs and docstrings

### DIFF
--- a/assyst/crystals.py
+++ b/assyst/crystals.py
@@ -172,7 +172,7 @@ class Formulas(Sequence):
 
     @property
     def elements(self) -> set[str]:
-        """Set of elements present in elements."""
+        """Set of elements present in all formula units."""
         e: set[str] = set()
         for s in self.atoms:
             e = e.union(s.keys())

--- a/assyst/filters.py
+++ b/assyst/filters.py
@@ -84,14 +84,14 @@ class DistanceFilter(FilterBase):
 
     def __call__(self, structure: Atoms) -> bool:
         """
-        Return True if structure satifies minimum distance criteria.
+        Return True if structure satisfies minimum distance criteria.
 
         Args:
             structure (:class:`ase.Atoms`): structure to check
 
         Returns:
-            `False`: at least on bond is shorter than the sum of given cutoff radii of the respective elements
-            `True`: all bonds are than the sum of given cutoff radii of the respective elements
+            `False`: at least one bond is shorter than the sum of given cutoff radii of the respective elements
+            `True`: all bonds are longer than the sum of given cutoff radii of the respective elements
         """
         pair = self._element_wise_dist(structure)
         for ei, ej in combinations_with_replacement(structure.symbols.species(), 2):

--- a/assyst/relaxations.py
+++ b/assyst/relaxations.py
@@ -20,7 +20,7 @@ import numpy as np
 class Relax:
     """Minimize energy with respect to internal positions.
 
-    Also used as a base class for all other relaxation."""
+    Also used as a base class for all other relaxation classes."""
 
     max_steps: int = 100
     force_tolerance: float = 1e-3

--- a/docs/background.rst
+++ b/docs/background.rst
@@ -4,7 +4,7 @@ Background
 Unlike molecular dynamics-based methods, which sample configurations along thermodynamic paths from a starting structure, this approach generates initial structures by random parametrization of crystallographic symmetry groups, requiring no pre-existing interatomic potential.
 The training set thereby covers broad regions of the potential energy surface independently of any specific target phase or thermal condition.
 
-The training strategy to achieve this splits in three steps:
+The training strategy to achieve this splits into three steps:
 
 1. the exploration of the PES with randomly generated, but symmetric, periodic crystals in 
 :ref:`assyst.crystals <crystals>`;
@@ -17,7 +17,7 @@ The training strategy to achieve this splits in three steps:
 
 These three steps are then combined and filtered based on configurable criteria to avoid unreasonable structures.
 
-This is illustrated in :ref:`below <schematic>`, with the steps 1-3 arranged on top in green, and the filtering step in
+This is illustrated :ref:`below <schematic>`, with the steps 1-3 arranged on top in green, and the filtering step in
 red.
 The final step is labelling the structures with high quality DFT, which is outside of the scope of this package.
 

--- a/docs/notebooks.rst
+++ b/docs/notebooks.rst
@@ -4,7 +4,7 @@ Notebooks
 These are introduction workflows using `assyst`.
 In :doc:`notebooks/SimpleUnary` we construct a full training set from start to finish and then in
 :doc:`notebooks/ACEFitting` fit a small, linear MLIP to it.
-This show cases all required steps in creating a running MLIP.
+This showcases all required steps in creating a running MLIP.
 
 :doc:`notebooks/Quickstart/Crystals` is a more detailed explanation how to construct chemical sampling in your training
 set.
@@ -12,13 +12,13 @@ set.
 :doc:`notebooks/PlotGallery` is a small gallery of available plots `assyst` offers for training data inspection.
 
 :doc:`notebooks/Lineage` shows some technical details that trace structures as they flow through the workflow, if you
-are interested in optimizing or debuging particular structures.
+are interested in optimizing or debugging particular structures.
 
 :doc:`notebooks/Relaxations` walks through the different relaxation modes available in :mod:`assyst.relaxations`
 (positions only, volume only, cell shape, symmetry-preserving, full), including how to apply pressure and switch
 optimizer algorithms.
 
-:doc:`notebooks/Perturbations` show cases the perturbations available in :mod:`assyst.perturbations` for generating
+:doc:`notebooks/Perturbations` showcases the perturbations available in :mod:`assyst.perturbations` for generating
 off-equilibrium training structures: gaussian rattling, element-scaled rattling, random cell stretching, and how to
 compose them in series or pick between alternatives at random.
 


### PR DESCRIPTION
## Summary

Small, unambiguous corrections found during a docs quality pass:

- **`docs/notebooks.rst`**: `"show cases"` → `"showcases"` (×2); `"debuging"` → `"debugging"`
- **`docs/background.rst`**: `"splits in three steps"` → `"splits into three steps"`; `"illustrated in :ref:below"` → `"illustrated :ref:below"` (removes the grammatically wrong "in")
- **`assyst/filters.py`** docstring: `"satifies"` → `"satisfies"`; `"at least on bond"` → `"at least one bond"`; `"all bonds are than"` → `"all bonds are longer than"`
- **`assyst/crystals.py`** `Formulas.elements` docstring: self-referential wording replaced with `"Set of elements present in all formula units."`
- **`assyst/relaxations.py`** `Relax` class docstring: `"all other relaxation"` → `"all other relaxation classes"`

## Test plan

- [ ] Verify the rendered docs still build without warnings (`make -C docs html`)
- [ ] Spot-check the five changed pages in the rendered output

https://claude.ai/code/session_01Bck4AVYDg9XuREejodjaAb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bck4AVYDg9XuREejodjaAb)_