### PR TITLE
fix: convert RST roles to MyST roles in notebooks

### DIFF
--- a/notebooks/Perturbations.ipynb
+++ b/notebooks/Perturbations.ipynb
@@ -4,19 +4,7 @@
    "cell_type": "markdown",
    "id": "intro-md",
    "metadata": {},
-   "source": [
-    "# Perturbations\n",
-    "\n",
-    "After relaxation, ASSYST perturbs structures to populate the training set with off-equilibrium configurations. This notebook walks through the perturbations available in :mod:`assyst.perturbations`:\n",
-    "\n",
-    "* :class:`~assyst.perturbations.Rattle` -- gaussian displacements of atomic positions\n",
-    "* :class:`~assyst.perturbations.ElementScaledRattle` -- gaussian displacements with per-element scaling\n",
-    "* :class:`~assyst.perturbations.Stretch` -- random affine cell deformation\n",
-    "* :class:`~assyst.perturbations.Series` -- chain perturbations together\n",
-    "* :class:`~assyst.perturbations.RandomChoice` -- pick between two perturbations at random\n",
-    "\n",
-    "Each can be applied directly to a single structure or via :func:`~assyst.perturbations.perturb` to a stream of structures, optionally filtered."
-   ]
+   "source": "# Perturbations\n\nAfter relaxation, ASSYST perturbs structures to populate the training set with off-equilibrium configurations. This notebook walks through the perturbations available in {mod}`assyst.perturbations`:\n\n* {class}`~assyst.perturbations.Rattle` -- gaussian displacements of atomic positions\n* {class}`~assyst.perturbations.ElementScaledRattle` -- gaussian displacements with per-element scaling\n* {class}`~assyst.perturbations.Stretch` -- random affine cell deformation\n* {class}`~assyst.perturbations.Series` -- chain perturbations together\n* {class}`~assyst.perturbations.RandomChoice` -- pick between two perturbations at random\n\nEach can be applied directly to a single structure or via {func}`~assyst.perturbations.perturb` to a stream of structures, optionally filtered."
   },
   {
    "cell_type": "code",
@@ -89,15 +77,7 @@
    "cell_type": "markdown",
    "id": "rattle-md",
    "metadata": {},
-   "source": [
-    "## `Rattle`\n",
-    "\n",
-    "Displace each atom by a gaussian-random vector with standard deviation `sigma` (in A). Use this to sample short-wavelength phonon-like distortions.\n",
-    "\n",
-    "The `rng` argument accepts either an integer seed or a :class:`numpy.random.Generator`; passing a seed makes the perturbation reproducible.\n",
-    "\n",
-    "Rattling a structure with a single atom is meaningless because of the periodic boundary, so the underlying :func:`~assyst.perturbations.rattle` raises ``ValueError``. Set ``create_supercells=True`` to automatically replicate to 2x2x2 first."
-   ]
+   "source": "## `Rattle`\n\nDisplace each atom by a gaussian-random vector with standard deviation `sigma` (in A). Use this to sample short-wavelength phonon-like distortions.\n\nThe `rng` argument accepts either an integer seed or a {class}`numpy.random.Generator`; passing a seed makes the perturbation reproducible.\n\nRattling a structure with a single atom is meaningless because of the periodic boundary, so the underlying {func}`~assyst.perturbations.rattle` raises ``ValueError``. Set ``create_supercells=True`` to automatically replicate to 2x2x2 first."
   },
   {
    "cell_type": "code",
@@ -234,11 +214,7 @@
    "cell_type": "markdown",
    "id": "series-md",
    "metadata": {},
-   "source": [
-    "## Composing perturbations\n",
-    "\n",
-    "Perturbations support `+` to chain into a :class:`~assyst.perturbations.Series` that applies each step in turn. The perturbation tag in `info[\"perturbation\"]` is built up accordingly so you can later see exactly what was done."
-   ]
+   "source": "## Composing perturbations\n\nPerturbations support `+` to chain into a {class}`~assyst.perturbations.Series` that applies each step in turn. The perturbation tag in `info[\"perturbation\"]` is built up accordingly so you can later see exactly what was done."
   },
   {
    "cell_type": "code",
@@ -399,11 +375,7 @@
    "cell_type": "markdown",
    "id": "filters-md",
    "metadata": {},
-   "source": [
-    "## Filters and retries\n",
-    "\n",
-    "Random perturbations occasionally produce unphysical configurations (atoms too close, extreme cell aspect ratios, ...). Pass any of the :mod:`assyst.filters` callables to drop or retry such candidates. With `retries=10` (the default) `perturb` re-rolls the random perturbation up to ten times before giving up on that input."
-   ]
+   "source": "## Filters and retries\n\nRandom perturbations occasionally produce unphysical configurations (atoms too close, extreme cell aspect ratios, ...). Pass any of the {mod}`assyst.filters` callables to drop or retry such candidates. With `retries=10` (the default) `perturb` re-rolls the random perturbation up to ten times before giving up on that input."
   }
  ],
  "metadata": {

--- a/notebooks/Relaxations.ipynb
+++ b/notebooks/Relaxations.ipynb
@@ -4,21 +4,7 @@
    "cell_type": "markdown",
    "id": "intro-md",
    "metadata": {},
-   "source": [
-    "# Relaxation Settings\n",
-    "\n",
-    "ASSYST provides several relaxation modes that differ in which degrees of freedom are minimized. They all share the same interface (see :class:`assyst.relaxations.Relax`) but apply different ASE filters and constraints to control whether positions, cell shape, volume, or symmetry are allowed to vary.\n",
-    "\n",
-    "This notebook walks through each option on a small Cu structure using ASE's EMT calculator so the examples run quickly.\n",
-    "\n",
-    "| Class | Positions | Cell shape | Volume | Symmetry |\n",
-    "|---|---|---|---|---|\n",
-    "| `Relax` | yes | fixed | fixed | free |\n",
-    "| `CellRelax` | fixed | yes | fixed | free |\n",
-    "| `VolumeRelax` | fixed | fixed | yes | free |\n",
-    "| `SymmetryRelax` | yes | yes | yes | preserved |\n",
-    "| `FullRelax` | yes | yes | yes | free |"
-   ]
+   "source": "# Relaxation Settings\n\nASSYST provides several relaxation modes that differ in which degrees of freedom are minimized. They all share the same interface (see {class}`assyst.relaxations.Relax`) but apply different ASE filters and constraints to control whether positions, cell shape, volume, or symmetry are allowed to vary.\n\nThis notebook walks through each option on a small Cu structure using ASE's EMT calculator so the examples run quickly.\n\n| Class | Positions | Cell shape | Volume | Symmetry |\n|---|---|---|---|---|\n| `Relax` | yes | fixed | fixed | free |\n| `CellRelax` | fixed | yes | fixed | free |\n| `VolumeRelax` | fixed | fixed | yes | free |\n| `SymmetryRelax` | yes | yes | yes | preserved |\n| `FullRelax` | yes | yes | yes | free |"
   },
   {
    "cell_type": "code",
@@ -95,9 +81,7 @@
    "cell_type": "markdown",
    "id": "helper-md",
    "metadata": {},
-   "source": [
-    "Helper to run a single relaxation through :func:`assyst.relaxations.relax` and print a summary."
-   ]
+   "source": "Helper to run a single relaxation through {func}`assyst.relaxations.relax` and print a summary."
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
Fixes #133

Convert RST-style roles (`:class:`, `:func:`, `:mod:`) to MyST roles (`{class}`, `{func}`, `{mod}`) in `Perturbations.ipynb` and `Relaxations.ipynb` so that Sphinx cross-references resolve correctly under myst_nb.

Generated with [Claude Code](https://claude.ai/code)