### PR TITLE
docs(filters): add OR-filter composition example

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -35,6 +35,14 @@ instances::
 The ``&`` operator short-circuits: the right-hand filter is only evaluated if
 the left-hand filter returns ``True``.
 
+``|`` builds a filter that accepts structures passing *either* condition —
+useful for mixing strict geometry filters with a relaxed energy fallback::
+
+    from assyst.filters import DistanceFilter, EnergyFilter
+
+    lenient = DistanceFilter({"Fe": 1.1}) | EnergyFilter(max_energy=-0.5)
+    good = list(filter(lenient, structures))
+
 Available filter classes
 ------------------------
 


### PR DESCRIPTION
Closes #128

## Change

The "Composing filters" section in `filters.rst` mentioned that `FilterBase` subclasses support both `&` and `|`, but only showed a `&` example. This adds a matching `|` snippet right below the `&` explanation so the prose and examples are consistent.

## Test plan
- [ ] `make -C docs html` builds without warnings
- [ ] Rendered filters page shows the new `|` example block

https://claude.ai/code/session_01Bck4AVYDg9XuREejodjaAb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bck4AVYDg9XuREejodjaAb)_