### PR TITLE
feat(workflow): full-workflow drivers (breadth-first / depth-first)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist/
 .ipynb_checkpoints/
 __pycache__/
 *.py[cod]
+.coverage
+.coverage.*

--- a/assyst/workflow.py
+++ b/assyst/workflow.py
@@ -1,0 +1,197 @@
+"""Convenience drivers that run a full ASSYST pipeline in one call.
+
+The individual stages of ASSYST (:func:`~assyst.relaxations.relax`,
+:func:`~assyst.perturbations.perturb`, filtering, …) all share the same
+shape: they consume an :class:`collections.abc.Iterable` of
+:class:`ase.Atoms` and yield another iterable of :class:`ase.Atoms`.  That
+makes them trivially composable, but the canonical workflow still has to be
+wired up by hand (see ``tests/reproducibility/test_full_workflow.py``).
+
+This module captures that wiring behind two drivers that take the *seed*
+structures plus an ordered list of :class:`Stage` objects:
+
+* :func:`breadth_first` runs each stage over the whole batch before moving
+  on to the next, returning every structure produced along the way -- the
+  full data set in one call.
+* :func:`depth_first` pushes each seed through the whole pipeline
+  independently, which makes the per-seed subtrees embarrassingly parallel.
+  An :class:`~concurrent.futures.Executor` (or anything exposing a
+  compatible ``map``) can be injected to dispatch them, e.g. across an HPC
+  allocation via `executorlib <https://github.com/pyiron/executorlib>`_.
+
+Both drivers return the same *set* of structures (deduplicated by their
+``uuid``); they only differ in the order in which the work is done and,
+hence, in the order of the returned list.
+
+A :class:`Stage` is simply a callable ``Iterable[Atoms] -> Iterable[Atoms]``.
+Any such callable works; the :class:`RelaxStage`, :class:`PerturbStage` and
+:class:`FilterStage` wrappers below bind a stage's configuration into a
+small frozen dataclass so that the resulting stage stays hashable and
+picklable -- a prerequisite for shipping it to remote workers.
+"""
+
+from dataclasses import dataclass
+from functools import partial
+from typing import Callable, Iterable, Iterator
+
+from ase import Atoms
+
+from .calculators import AseCalculatorConfig
+from .filters import Filter
+from .perturbations import Perturbation, perturb
+from .relaxations import Relax, relax
+
+from ase.calculators.calculator import Calculator
+
+
+Stage = Callable[[Iterable[Atoms]], Iterable[Atoms]]
+"""A single workflow step: maps an iterable of structures to another one."""
+
+
+@dataclass(frozen=True)
+class RelaxStage:
+    """A :func:`~assyst.relaxations.relax` call with its configuration bound.
+
+    Args:
+        settings (:class:`~assyst.relaxations.Relax`): the kind of relaxation to perform
+        calculator (:class:`~assyst.calculators.AseCalculatorConfig` or :class:`ase.calculators.calculator.Calculator`): the energy/force engine to use
+    """
+
+    settings: Relax
+    calculator: AseCalculatorConfig | Calculator
+
+    def __call__(self, structures: Iterable[Atoms]) -> Iterator[Atoms]:
+        return relax(structures, self.settings, self.calculator)
+
+
+@dataclass(frozen=True)
+class PerturbStage:
+    """A :func:`~assyst.perturbations.perturb` call with its configuration bound.
+
+    Args:
+        perturbations (:class:`tuple` of :class:`~assyst.perturbations.Perturbation`): perturbations to apply to each structure
+        filters (:class:`~assyst.filters.Filter` or iterable thereof, optional): filters every perturbed structure must pass
+        retries (:class:`int`): max attempts per perturbation (default: 10)
+    """
+
+    perturbations: tuple[Perturbation, ...]
+    filters: Iterable[Filter] | Filter | None = None
+    retries: int = 10
+
+    def __call__(self, structures: Iterable[Atoms]) -> Iterator[Atoms]:
+        return perturb(
+            structures,
+            self.perturbations,
+            filters=self.filters,
+            retries=self.retries,
+        )
+
+
+@dataclass(frozen=True)
+class FilterStage:
+    """Drop structures that do not pass `filter` from the stream.
+
+    Filtering does not create new structures, so a :class:`FilterStage`
+    never adds anything to the data set collected by the drivers; it only
+    narrows what flows on to the following stages.
+
+    Args:
+        filter (:class:`~assyst.filters.Filter`): predicate a structure must satisfy to be kept
+    """
+
+    filter: Filter
+
+    def __call__(self, structures: Iterable[Atoms]) -> Iterator[Atoms]:
+        return filter(self.filter, structures)
+
+
+def _key(structure: Atoms):
+    """Stable identity for deduplication: the uuid if present, else object id."""
+    return structure.info.get("uuid", id(structure))
+
+
+def _dedup(structures: Iterable[Atoms]) -> list[Atoms]:
+    """Return the structures with duplicate uuids removed, keeping first occurrence."""
+    seen = set()
+    out = []
+    for s in structures:
+        k = _key(s)
+        if k in seen:
+            continue
+        seen.add(k)
+        out.append(s)
+    return out
+
+
+def breadth_first(
+    structures: Iterable[Atoms],
+    stages: Iterable[Stage],
+) -> list[Atoms]:
+    """Run every stage over the whole batch and collect all structures produced.
+
+    The seed `structures` are passed through the first stage, whose output
+    is passed through the second, and so on.  The returned list is the union
+    of the seeds and the output of *every* stage, i.e. the full data set of
+    the workflow in one call.  Structures sharing a ``uuid`` (for example the
+    ones a :class:`FilterStage` lets through unchanged) appear only once.
+
+    Args:
+        structures (:class:`collections.abc.Iterable` of :class:`ase.Atoms`): the seed structures, e.g. from :func:`~assyst.crystals.sample`
+        stages (:class:`collections.abc.Iterable` of :class:`Stage`): the workflow steps to run, in order
+
+    Returns:
+        :class:`list` of :class:`ase.Atoms`: the seeds together with every intermediate and final structure
+    """
+    current = list(structures)
+    collected = list(current)
+    for stage in stages:
+        current = list(stage(current))
+        collected.extend(current)
+    return _dedup(collected)
+
+
+def depth_first(
+    structures: Iterable[Atoms],
+    stages: Iterable[Stage],
+    executor=None,
+) -> list[Atoms]:
+    """Push each seed through the whole pipeline independently and collect the result.
+
+    Each seed is run through all `stages` on its own, so the subtree of
+    structures derived from one seed never depends on any other seed.  These
+    per-seed jobs are therefore embarrassingly parallel: pass an `executor`
+    to dispatch them concurrently (e.g. across an HPC allocation), otherwise
+    they run sequentially.
+
+    The returned data set is identical to :func:`breadth_first` for the same
+    inputs; only the order differs (grouped by seed rather than by stage).
+
+    Args:
+        structures (:class:`collections.abc.Iterable` of :class:`ase.Atoms`): the seed structures, e.g. from :func:`~assyst.crystals.sample`
+        stages (:class:`collections.abc.Iterable` of :class:`Stage`): the workflow steps to run, in order
+        executor (:class:`concurrent.futures.Executor`, optional): anything exposing a compatible ``map``; used to dispatch the per-seed jobs. Defaults to serial execution. ``stages`` must be picklable when a process- or HPC-based executor is used.
+
+    Returns:
+        :class:`list` of :class:`ase.Atoms`: the seeds together with every intermediate and final structure
+    """
+    seeds = list(structures)
+    # Materialise so the same stages can drive every independent seed and so
+    # they can be shipped to remote workers.
+    stages = list(stages)
+    run_seed = partial(breadth_first, stages=stages)
+    inputs = ([seed] for seed in seeds)
+    _map = map if executor is None else executor.map
+    collected = []
+    for subtree in _map(run_seed, inputs):
+        collected.extend(subtree)
+    return _dedup(collected)
+
+
+__all__ = [
+    "Stage",
+    "RelaxStage",
+    "PerturbStage",
+    "FilterStage",
+    "breadth_first",
+    "depth_first",
+]

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -9,4 +9,5 @@ assyst
    perturbations
    filters
    calculators
+   workflow
    plot

--- a/docs/api/workflow.rst
+++ b/docs/api/workflow.rst
@@ -1,0 +1,7 @@
+assyst.workflow
+===============
+
+.. automodule:: assyst.workflow
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/tests/pickling/test_workflow.py
+++ b/tests/pickling/test_workflow.py
@@ -1,0 +1,23 @@
+import pickle
+
+from assyst.calculators import Morse
+from assyst.filters import DistanceFilter
+from assyst.perturbations import Rattle, Stretch
+from assyst.relaxations import FullRelax, VolumeRelax
+from assyst.workflow import FilterStage, PerturbStage, RelaxStage
+
+
+def test_pickling_stages():
+    stages = [
+        RelaxStage(VolumeRelax(max_steps=3), Morse(epsilon=0.3, r0=2.5, rho0=4)),
+        RelaxStage(FullRelax(max_steps=3), Morse()),
+        PerturbStage(
+            (Rattle(0.25, rng=0), Stretch(hydro=0.05, shear=0.005, rng=0)),
+            filters=[DistanceFilter({"Cu": 1})],
+        ),
+        FilterStage(DistanceFilter({"Cu": 1})),
+    ]
+
+    for stage in stages:
+        loaded = pickle.loads(pickle.dumps(stage))
+        assert type(loaded) is type(stage)

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,197 @@
+"""Tests for the full-workflow drivers in :mod:`assyst.workflow`."""
+
+from dataclasses import dataclass
+
+import numpy as np
+from ase import Atoms
+
+from assyst.calculators import Morse
+from assyst.crystals import Formulas, sample
+from assyst.filters import AspectFilter, DistanceFilter
+from assyst.perturbations import Rattle, Stretch
+from assyst.relaxations import FullRelax, VolumeRelax
+from assyst.workflow import (
+    PerturbStage,
+    RelaxStage,
+    breadth_first,
+    depth_first,
+)
+
+
+# --- deterministic synthetic stages, so set membership can be checked exactly ---
+
+
+@dataclass(frozen=True)
+class Tag:
+    """Synthetic stage: emit a child per structure with a deterministic uuid.
+
+    Defined at module level (and picklable) so it can be shipped to a process
+    based executor in the depth-first tests.
+    """
+
+    tag: str
+
+    def __call__(self, structures):
+        for s in structures:
+            child = s.copy()
+            child.info["uuid"] = s.info["uuid"] + self.tag
+            yield child
+
+
+@dataclass(frozen=True)
+class KeepWithTag:
+    """Synthetic filter stage keeping only structures whose uuid contains `needle`."""
+
+    needle: str
+
+    def __call__(self, structures):
+        return (s for s in structures if self.needle in s.info["uuid"])
+
+
+class SerialExecutor:
+    """Minimal executor stub exposing the ``map`` seam depth_first relies on."""
+
+    def map(self, fn, iterable):
+        return [fn(x) for x in iterable]
+
+
+def make_seeds(names):
+    seeds = []
+    for name in names:
+        a = Atoms("Cu", positions=[[0, 0, 0]], cell=np.eye(3) * 4, pbc=True)
+        a.info["uuid"] = name
+        seeds.append(a)
+    return seeds
+
+
+def uuids(structures):
+    return [s.info["uuid"] for s in structures]
+
+
+# --------------------------------------------------------------------------- #
+# Driver semantics on synthetic, fully deterministic stages
+# --------------------------------------------------------------------------- #
+
+
+def test_breadth_first_collects_seeds_and_every_stage():
+    seeds = make_seeds(["a", "b"])
+    result = breadth_first(seeds, [Tag("/1"), Tag("/2")])
+    # seeds + first stage + second stage, all distinct
+    assert uuids(result) == ["a", "b", "a/1", "b/1", "a/1/2", "b/1/2"]
+
+
+def test_breadth_first_no_stages_returns_seeds():
+    seeds = make_seeds(["a", "b"])
+    assert uuids(breadth_first(seeds, [])) == ["a", "b"]
+
+
+def test_filter_stage_narrows_flow_without_duplicating():
+    seeds = make_seeds(["a", "b", "c"])
+    # keep only 'a' and 'c', then tag the survivors
+    result = breadth_first(seeds, [KeepWithTag("a"), KeepWithTag("c")])
+    # the filtered structures keep their uuid, so they are deduplicated away;
+    # only 'a' survives both filters and it is already among the seeds
+    assert uuids(result) == ["a", "b", "c"]
+
+    result = breadth_first(seeds, [KeepWithTag("a"), Tag("/x")])
+    # 'a' passes the filter and is then tagged; 'b'/'c' never flow onward
+    assert uuids(result) == ["a", "b", "c", "a/x"]
+
+
+def test_depth_first_matches_breadth_first_set():
+    seeds = make_seeds(["a", "b", "c"])
+    stages = [Tag("/1"), Tag("/2")]
+    bf = breadth_first(seeds, stages)
+    df = depth_first(seeds, stages)
+    # identical data set, only the ordering differs (grouped by seed)
+    assert set(uuids(df)) == set(uuids(bf))
+    assert len(df) == len(bf)
+    # depth-first groups every seed's subtree together
+    assert uuids(df) == ["a", "a/1", "a/1/2", "b", "b/1", "b/1/2", "c", "c/1", "c/1/2"]
+
+
+def test_depth_first_accepts_injected_executor():
+    seeds = make_seeds(["a", "b", "c"])
+    stages = [Tag("/1"), Tag("/2")]
+    serial = depth_first(seeds, stages)
+    via_executor = depth_first(seeds, stages, executor=SerialExecutor())
+    assert uuids(via_executor) == uuids(serial)
+
+
+def test_depth_first_with_process_pool():
+    # Exercises the real parallel path: stages must survive pickling and run
+    # in a separate process.
+    from concurrent.futures import ProcessPoolExecutor
+
+    seeds = make_seeds(["a", "b", "c"])
+    stages = [Tag("/1"), Tag("/2")]
+    expected = set(uuids(breadth_first(seeds, stages)))
+    with ProcessPoolExecutor(max_workers=2) as executor:
+        result = depth_first(seeds, stages, executor=executor)
+    assert set(uuids(result)) == expected
+
+
+# --------------------------------------------------------------------------- #
+# Integration: a real sample -> relax -> relax -> perturb pipeline
+# --------------------------------------------------------------------------- #
+
+
+def make_pipeline_stages():
+    reference = Morse(epsilon=0.3, r0=2.55265548 * 1.10619396, rho0=4)
+    return [
+        RelaxStage(VolumeRelax(max_steps=3, force_tolerance=1e-2), reference),
+        RelaxStage(FullRelax(max_steps=3, force_tolerance=1e-2), reference),
+        PerturbStage(
+            (Rattle(0.25, rng=0), Stretch(hydro=0.05, shear=0.005, rng=0)),
+            filters=[DistanceFilter({"Cu": 1})],
+        ),
+    ]
+
+
+def test_real_pipeline_breadth_first_runs():
+    rng = np.random.default_rng(0)
+    seeds = list(
+        filter(
+            AspectFilter(6),
+            sample(Formulas.range("Cu", 3), spacegroups=[225, 194], max_atoms=2, rng=rng),
+        )
+    )
+    assert len(seeds) > 0
+
+    result = breadth_first(seeds, make_pipeline_stages())
+
+    # every seed is part of the full data set, and everything is a real,
+    # uuid-tracked structure
+    seed_ids = set(uuids(seeds))
+    result_ids = set(uuids(result))
+    assert seed_ids <= result_ids
+    assert all(isinstance(s, Atoms) for s in result)
+    # relaxation alone produces a relaxed copy of each seed in both stages
+    assert len(result) > len(seeds)
+
+
+def test_real_pipeline_depth_first_same_dataset_as_breadth_first():
+    rng = np.random.default_rng(0)
+    seeds = list(
+        filter(
+            AspectFilter(6),
+            sample(Formulas.range("Cu", 3), spacegroups=[225, 194], max_atoms=2, rng=rng),
+        )
+    )
+    assert len(seeds) > 0
+
+    # Fresh stages per driver so the perturbation RNGs start from the same
+    # state; serial depth-first consumes the RNG in the same order as
+    # breadth-first, so the generated structures are identical.
+    bf = breadth_first(seeds, make_pipeline_stages())
+    df = depth_first(seeds, make_pipeline_stages())
+
+    def fingerprint(s):
+        return (
+            s.get_chemical_formula(),
+            tuple(np.round(s.positions.flatten(), 5)),
+            tuple(np.round(s.cell.array.flatten(), 5)),
+        )
+
+    assert len(df) == len(bf)
+    assert sorted(map(fingerprint, df)) == sorted(map(fingerprint, bf))

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -11,6 +11,7 @@ from assyst.filters import AspectFilter, DistanceFilter
 from assyst.perturbations import Rattle, Stretch
 from assyst.relaxations import FullRelax, VolumeRelax
 from assyst.workflow import (
+    FilterStage,
     PerturbStage,
     RelaxStage,
     breadth_first,
@@ -96,6 +97,15 @@ def test_filter_stage_narrows_flow_without_duplicating():
     result = breadth_first(seeds, [KeepWithTag("a"), Tag("/x")])
     # 'a' passes the filter and is then tagged; 'b'/'c' never flow onward
     assert uuids(result) == ["a", "b", "c", "a/x"]
+
+
+def test_filter_stage_applies_predicate():
+    seeds = make_seeds(["a", "b", "c"])
+    # real FilterStage with a plain predicate, then tag the survivors
+    keep = FilterStage(lambda s: s.info["uuid"] != "b")
+    result = breadth_first(seeds, [keep, Tag("/x")])
+    # 'b' is filtered out before the tagging stage and so is never tagged
+    assert uuids(result) == ["a", "b", "c", "a/x", "c/x"]
 
 
 def test_depth_first_matches_breadth_first_set():


### PR DESCRIPTION
Closes #112.

Adds a new `assyst.workflow` module with two convenience drivers that run a complete ASSYST pipeline from seed structures in a single call, so the canonical sample → relax → … → perturb workflow no longer has to be wired up by hand (cf. `tests/reproducibility/test_full_workflow.py`).

## What's new

- **`breadth_first(structures, stages)`** — runs each stage over the whole batch before the next, returning the union of the seeds and *every* stage's output: the full data set in one call.
- **`depth_first(structures, stages, executor=None)`** — pushes each seed through the whole pipeline independently. The per-seed subtrees are embarrassingly parallel, so an optional `executor` (anything with a compatible `map`; serial by default) dispatches them, e.g. across an HPC allocation via [executorlib](https://github.com/pyiron/executorlib).

Both drivers return the **same data set** (only the ordering differs); structures are deduplicated by `uuid`.

A `Stage` is any `Iterable[Atoms] -> Iterable[Atoms]` callable. The `RelaxStage`, `PerturbStage` and `FilterStage` wrappers bind a stage's configuration into a frozen, **picklable** dataclass so stages can be shipped to remote workers. Because filtering keeps a structure's `uuid` unchanged, a `FilterStage` narrows the forward flow without ever adding duplicates to the collected set.

```python
from assyst.crystals import Formulas, sample
from assyst.calculators import Morse
from assyst.relaxations import VolumeRelax, FullRelax
from assyst.perturbations import Rattle, Stretch
from assyst.filters import DistanceFilter
from assyst.workflow import RelaxStage, PerturbStage, breadth_first, depth_first

calc = Morse()
seeds = list(sample(Formulas.range("Cu", 1, 5)))
stages = [
    RelaxStage(VolumeRelax(), calc),
    RelaxStage(FullRelax(), calc),
    PerturbStage((Rattle(0.1), Stretch(0.05, 0.005)), filters=[DistanceFilter({"Cu": 1})]),
]

training_set = breadth_first(seeds, stages)          # everything in one call
# or, to fan the per-seed work out over a cluster:
# with MyExecutor() as ex:
#     training_set = depth_first(seeds, stages, executor=ex)
```

## Design notes / decisions
- **Executor injection** (serial default) was chosen over built-in parallelism to match ASSYST's "loosely coupled, dispatch externally" philosophy.
- **Width-first returns all intermediates combined** (seeds + every stage), reproducing the manual `spg + volmin + allmin + random` pattern.
- Sampling stays the caller's responsibility, since `sample` is a source with a different signature than the transform stages; both drivers take the resulting seed structures.

## Tests
- Unit tests for driver semantics on deterministic synthetic stages (collection, dedup, filter narrowing, breadth/depth set-equivalence).
- Executor injection via a stub and a real `ProcessPoolExecutor` (exercises pickling + cross-process execution).
- Integration test of a real `sample → relax → relax → perturb` pipeline, asserting `breadth_first` and serial `depth_first` produce an identical data set.
- Pickling test for the stage wrappers.

Full suite green locally (170 passed, 12 skipped) and `ruff` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhABprRhsvN7gxFHU5oLSQ)_