### PR TITLE
ci: persist Hypothesis example database as GitHub artifact

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -28,5 +28,16 @@ jobs:
         pip install -e .[test,plotneighborlist]
     - name: run tests
       shell: bash -l {0}
+      env:
+        HYPOTHESIS_ARTIFACT_NAME: hypothesis-example-db-py${{ matrix.python-version }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         pytest
+    - name: Upload Hypothesis example database
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: hypothesis-example-db-py${{ matrix.python-version }}
+        path: .hypothesis/examples
+        if-no-files-found: ignore
+        retention-days: 90

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest>=7.4", "hypothesis>=6.20"]
+test = ["pytest>=7.4", "hypothesis>=6.71"]
 doc = ["sphinx", "furo", "myst-nb"]
-coverage = ["pytest>=7.4", "hypothesis>=6.20", "pytest-cov"]
+coverage = ["pytest>=7.4", "hypothesis>=6.71", "pytest-cov"]
 grace = ["tensorpotential>=0.5.1,<0.5.10"]
 plotneighborlist = ["matscipy>=1,<2"]
 notebooks = ["tensorpotential>=0.5.1,<0.5.10", "pandas>=2.2,<4",]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+import os
+
+from hypothesis import settings
+from hypothesis.database import (
+    DirectoryBasedExampleDatabase,
+    GitHubArtifactDatabase,
+    MultiplexedDatabase,
+    ReadOnlyDatabase,
+)
+
+
+if os.environ.get("GITHUB_ACTIONS") == "true":
+    _local = DirectoryBasedExampleDatabase(".hypothesis/examples")
+    _shared = ReadOnlyDatabase(
+        GitHubArtifactDatabase(
+            "eisenforschung",
+            "assyst",
+            artifact_name=os.environ.get(
+                "HYPOTHESIS_ARTIFACT_NAME", "hypothesis-example-db"
+            ),
+        )
+    )
+    settings.register_profile("ci", database=MultiplexedDatabase(_local, _shared))
+    settings.load_profile("ci")


### PR DESCRIPTION
Port of pmrv/fleche#668.

New `tests/conftest.py` registers a `ci` Hypothesis profile under `GITHUB_ACTIONS=true` that multiplexes a local `DirectoryBasedExampleDatabase(".hypothesis/examples")` with a read-only `GitHubArtifactDatabase("eisenforschung", "assyst", artifact_name=...)`. The artifact name defaults to `hypothesis-example-db` and is overridden per matrix job via `HYPOTHESIS_ARTIFACT_NAME`.

`.github/workflows/unittest.yml` sets `HYPOTHESIS_ARTIFACT_NAME=hypothesis-example-db-py${{ matrix.python-version }}` and `GITHUB_TOKEN` on the test step, then uploads `.hypothesis/examples` as that artifact (`if-no-files-found: ignore`, 90 day retention, `if: always()`).

No source / test changes outside CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TkoH55C7xe3TBkqjFQVM5m)_