### PR TITLE
ci(claude): default mention model to sonnet

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,7 +39,7 @@ jobs:
           ISSUE_TITLE: ${{ github.event.issue.title }}
         run: |
           body="${COMMENT_BODY}${REVIEW_BODY}${ISSUE_BODY}${ISSUE_TITLE}"
-          model=opus
+          model=sonnet
           if [[ "$body" =~ @claude\[([a-zA-Z]+)\] ]]; then
             choice="${BASH_REMATCH[1],,}"
             case "$choice" in


### PR DESCRIPTION
The `@claude` mention workflow (`.github/workflows/claude.yml`) already
resolves an `@claude[haiku|sonnet|opus]` switch into `--model`. This
changes the fallback default in the `Resolve model from mention` step
from `opus` to `sonnet`, so bare `@claude` mentions and unknown aliases
now run on sonnet. The unknown-alias warning text follows automatically
since it interpolates `$model`.

The bracket switch itself is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDQFf5cqrEedPEWiGfidG9)_