### PR TITLE
ci: run tests and coverage on all PRs, not just main-targeting ones

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
+    branches: [ main ]
 
 jobs:
   coverage:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   coverage:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

- **`unittest.yml`**: remove `branches: [main]` from the `pull_request` trigger so the full test matrix (Python 3.11–3.14) runs on all PRs, not only those targeting `main`
- **`codecov.yml`**: same fix so coverage reports are generated on all PRs
- **`test-minimum-deps.yml`**: left unchanged — the lowest-direct-resolution check intentionally stays restricted to main-targeting PRs

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXyqGZu8N8fxYoucvcWSHp)_