### PR TITLE
ci: gate test/coverage workflows on source/test/workflow changes

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -7,7 +7,24 @@ on:
     branches: [ main ]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            run:
+              - 'assyst/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - '.github/workflows/**'
+
   coverage:
+    needs: changes
     strategy:
       fail-fast: false
       matrix:
@@ -15,21 +32,29 @@ jobs:
         os: ["ubuntu-latest"]
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Skip notice
+      if: needs.changes.outputs.run != 'true'
+      run: echo "No source, test, or workflow changes; skipping."
     - uses: actions/checkout@v4
+      if: needs.changes.outputs.run == 'true'
       with:
         fetch-depth: 2
     - name: Set up Python ${{ matrix.python-version }}
+      if: needs.changes.outputs.run == 'true'
       uses: actions/setup-python@v6
       with:
         cache: pip
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
+      if: needs.changes.outputs.run == 'true'
       run: |
         pip install -e .[coverage]
     - name: Run tests and generate report
+      if: needs.changes.outputs.run == 'true'
       run: |
         pytest --cov --cov-branch --cov-report=xml
     - name: Upload coverage to Codecov
+      if: needs.changes.outputs.run == 'true'
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -21,7 +21,7 @@ jobs:
               - 'assyst/**'
               - 'tests/**'
               - 'pyproject.toml'
-              - '.github/workflows/**'
+              - '.github/workflows/codecov.yml'
 
   coverage:
     needs: changes

--- a/.github/workflows/test-minimum-deps.yml
+++ b/.github/workflows/test-minimum-deps.yml
@@ -21,7 +21,7 @@ jobs:
               - 'assyst/**'
               - 'tests/**'
               - 'pyproject.toml'
-              - '.github/workflows/**'
+              - '.github/workflows/test-minimum-deps.yml'
 
   test-minimum-deps:
     needs: changes

--- a/.github/workflows/test-minimum-deps.yml
+++ b/.github/workflows/test-minimum-deps.yml
@@ -7,18 +7,43 @@ on:
     branches: [ main ]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            run:
+              - 'assyst/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - '.github/workflows/**'
+
   test-minimum-deps:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
+      - name: Skip notice
+        if: needs.changes.outputs.run != 'true'
+        run: echo "No source, test, or workflow changes; skipping."
       - uses: actions/checkout@v5
+        if: needs.changes.outputs.run == 'true'
         with:
           # setuptools-scm derives the version from git history.
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v5
+        if: needs.changes.outputs.run == 'true'
       # Pin the lowest supported Python: minimum deps go with minimum Python,
       # and the declared floors are the first versions shipping 3.11 wheels.
       - run: uv venv --python 3.11
+        if: needs.changes.outputs.run == 'true'
       # --resolution lowest-direct pins every direct dependency to the lowest
       # version its bound allows, exercising the floors declared in pyproject.
       - run: uv pip install --resolution lowest-direct -e ".[test,plotneighborlist]"
+        if: needs.changes.outputs.run == 'true'
       - run: uv run --no-sync pytest
+        if: needs.changes.outputs.run == 'true'

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -21,7 +21,7 @@ jobs:
               - 'assyst/**'
               - 'tests/**'
               - 'pyproject.toml'
-              - '.github/workflows/**'
+              - '.github/workflows/unittest.yml'
 
   build:
     needs: changes

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -7,7 +7,24 @@ on:
   pull_request:
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            run:
+              - 'assyst/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - '.github/workflows/**'
+
   build:
+    needs: changes
     strategy:
       fail-fast: false
       matrix:
@@ -15,17 +32,24 @@ jobs:
         os: ["ubuntu-latest"]
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Skip notice
+      if: needs.changes.outputs.run != 'true'
+      run: echo "No source, test, or workflow changes; skipping."
     - uses: actions/checkout@v5
+      if: needs.changes.outputs.run == 'true'
     - name: Set up Python ${{ matrix.python-version }}
+      if: needs.changes.outputs.run == 'true'
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
     - name: Setup
+      if: needs.changes.outputs.run == 'true'
       shell: bash -l {0}
       run: |
         pip install -e .[test,plotneighborlist]
     - name: run tests
+      if: needs.changes.outputs.run == 'true'
       shell: bash -l {0}
       env:
         HYPOTHESIS_ARTIFACT_NAME: hypothesis-example-db-py${{ matrix.python-version }}
@@ -33,7 +57,7 @@ jobs:
       run: |
         pytest
     - name: Upload Hypothesis example database
-      if: always()
+      if: needs.changes.outputs.run == 'true' && always()
       uses: actions/upload-artifact@v4
       with:
         name: hypothesis-example-db-py${{ matrix.python-version }}


### PR DESCRIPTION
Add a `changes` gate job (`dorny/paths-filter`) to `unittest.yml`, `test-minimum-deps.yml`, and `codecov.yml` so the jobs only do work when relevant files change.

Each workflow's filter matches:
- the source dir (`assyst/**`)
- `tests/**`
- `pyproject.toml`
- its own workflow file (e.g. `unittest.yml` gates on `.github/workflows/unittest.yml`)

So editing one workflow re-runs only that workflow, not the others. Steps are gated per-step (`if: needs.changes.outputs.run == 'true'`) with a "Skip notice" step, matching the pattern already used in `pmrv/fleche`, so the jobs still report green when skipped and remain valid as required status checks. A push/PR that only touches docs, notebooks, etc. no longer spins up the unittest matrix, coverage upload, or minimum-deps run.