### PR TITLE
feat(utils): update_uuid tracks what changed

### DIFF
--- a/assyst/crystals.py
+++ b/assyst/crystals.py
@@ -98,7 +98,7 @@ def pyxtal(
             else:
                 return None
         s = s.to_ase()
-        update_uuid(s)
+        update_uuid(s, change="pyxtal")
         s.wrap(center=(0, 0, 0))
         return s
 

--- a/assyst/perturbations.py
+++ b/assyst/perturbations.py
@@ -129,7 +129,7 @@ class PerturbationABC(ABC):
     """Apply some perturbation to a given structure."""
 
     def __call__(self, structure: Atoms) -> Atoms:
-        update_uuid(structure)
+        update_uuid(structure, change=str(self))
         if "perturbation" not in structure.info:
             structure.info["perturbation"] = str(self)
         else:

--- a/assyst/relaxations.py
+++ b/assyst/relaxations.py
@@ -45,7 +45,7 @@ class Relax:
         """
         calc = structure.calc
         structure = structure.copy()
-        update_uuid(structure)
+        update_uuid(structure, change=type(self).__name__)
         structure.calc = calc
         optimizer_cls = {"LBFGS": LBFGS, "BFGS": BFGS, "FIRE": FIRE}[self.algorithm]
         optimizer = optimizer_cls(self.apply_filter_and_constraints(structure), logfile="/dev/null")

--- a/assyst/utils.py
+++ b/assyst/utils.py
@@ -1,7 +1,7 @@
 import uuid
 from ase import Atoms
 
-def update_uuid(structure: Atoms) -> Atoms:
+def update_uuid(structure: Atoms, change: str | None = None) -> Atoms:
     """Updates the UUID of the structure and maintains a lineage.
 
     If the structure already has a UUID, it is appended to the 'lineage' list.
@@ -9,6 +9,8 @@ def update_uuid(structure: Atoms) -> Atoms:
 
     Args:
         structure (ase.Atoms): The structure to update.
+        change (str, optional): Description of what produced this new UUID, e.g. the name of a
+            relaxation or sampling step. Stored in the 'change' key of `info` when given.
 
     Returns:
         ase.Atoms: The updated structure.
@@ -24,5 +26,8 @@ def update_uuid(structure: Atoms) -> Atoms:
 
     if 'seed' not in structure.info:
         structure.info['seed'] = new_uuid
+
+    if change is not None:
+        structure.info['change'] = change
 
     return structure

--- a/docs/lineage.rst
+++ b/docs/lineage.rst
@@ -12,19 +12,20 @@ Workflow Integration
 Initial Generation
 ~~~~~~~~~~~~~~~~~~
 
-When a structure is first generated using :func:`.pyxtal` (or through :func:`.sample`), it is assigned a new UUID.
+When a structure is first generated using :func:`.pyxtal` (or through :func:`.sample`), it is assigned a new UUID and ``change`` is set to ``"pyxtal"``.
 At this stage, the ``seed`` is set to the same UUID, and the ``lineage`` is empty.
 
 Perturbations
 ~~~~~~~~~~~~~
 
-Whenever a :class:`.PerturbationABC` (like :class:`.Rattle` or :class:`.Stretch`) is applied to a structure, a new UUID is generated.
+Whenever a :class:`.PerturbationABC` (like :class:`.Rattle` or :class:`.Stretch`) is applied to a structure, a new UUID is generated and ``change`` is set to that perturbation's own string form (e.g. ``rattle(0.1)``).
 The previous UUID is appended to the ``lineage`` list. The ``seed`` remains unchanged.
+The cumulative ``perturbation`` key still records every step of a :class:`.Series`, while ``change`` only reflects the most recent one.
 
 Relaxations
 ~~~~~~~~~~~
 
-Similarly, the :meth:`.Relax.relax` method generates a new UUID for the relaxed structure and updates the lineage.
+Similarly, the :meth:`.Relax.relax` method generates a new UUID for the relaxed structure, updates the lineage, and sets ``change`` to the relaxation class's name (e.g. ``VolumeRelax``).
 
 Example
 -------

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -12,6 +12,7 @@ These keys are managed by the :func:`assyst.utils.update_uuid` function and are 
 * ``uuid``: A Universally Unique Identifier (UUID) for the current structure.
 * ``seed``: The UUID of the initial structure from which this structure was derived. It remains constant throughout a lineage.
 * ``lineage``: A list of UUIDs of all parent structures, in the order they were generated.
+* ``change``: A description of the step that produced the current UUID (e.g. ``VolumeRelax``, ``pyxtal``, or a perturbation's own string form). Only set when the caller of :func:`assyst.utils.update_uuid` provides one; it reflects the most recent step only, not the full history.
 
 For more details on how lineage is tracked through the workflow, see :doc:`lineage`.
 

--- a/tests/test_perturbations.py
+++ b/tests/test_perturbations.py
@@ -51,6 +51,19 @@ class TestPerturbations(unittest.TestCase):
         rattled_structure = rattle_pert(self.structure.copy())
         self.assertIn('rattle(0.1)', rattled_structure.info['perturbation'])
 
+    def test_rattle_class_records_change(self):
+        """Test that applying a perturbation also records it under 'change'."""
+        rattle_pert = Rattle(sigma=0.1)
+        rattled_structure = rattle_pert(self.structure.copy())
+        self.assertEqual(rattled_structure.info['change'], 'rattle(0.1)')
+
+    def test_series_records_last_change(self):
+        """Test that a Series records only its last step under 'change', unlike the cumulative 'perturbation'."""
+        series = Series((Rattle(sigma=0.1), Stretch(hydro=0.1, shear=0.1)))
+        result = series(self.structure.copy())
+        self.assertEqual(result.info['change'], str(Stretch(hydro=0.1, shear=0.1)))
+        self.assertEqual(result.info['perturbation'], 'rattle(0.1)+stretch(hydro=0.1, shear=0.1)')
+
     def test_rattle_class_supercell(self):
         """Test the Rattle class with create_supercells=True."""
         rattle_pert = Rattle(sigma=0.1, create_supercells=True)

--- a/tests/test_relax.py
+++ b/tests/test_relax.py
@@ -231,6 +231,16 @@ def test_relax_assigns_seed_if_absent(cu_structure):
     assert result.info["seed"] == result.info["uuid"]
 
 
+def test_relax_records_change_as_class_name(cu_structure):
+    result = Relax(max_steps=5).relax(cu_structure)
+    assert result.info["change"] == "Relax"
+
+
+def test_volume_relax_records_change_as_class_name(cu_structure):
+    result = VolumeRelax(max_steps=5).relax(cu_structure)
+    assert result.info["change"] == "VolumeRelax"
+
+
 def test_relax_reduces_energy():
     s = bulk("Cu", cubic=True)
     s.positions[0] += 0.3

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -61,6 +61,25 @@ def test_update_uuid_preserves_seed(atoms):
 
     assert updated_atoms.info['seed'] == original_seed
 
+def test_update_uuid_no_change_by_default(atoms):
+    """Test that update_uuid does not touch 'change' when not given one."""
+    updated_atoms = update_uuid(atoms)
+
+    assert 'change' not in updated_atoms.info
+
+def test_update_uuid_records_change(atoms):
+    """Test that update_uuid stores the given change description."""
+    updated_atoms = update_uuid(atoms, change="relax")
+
+    assert updated_atoms.info['change'] == "relax"
+
+def test_update_uuid_change_overwritten_on_next_call(atoms):
+    """Test that a later call's change replaces the previous one, like 'uuid' does."""
+    update_uuid(atoms, change="sample")
+    updated_atoms = update_uuid(atoms, change="relax")
+
+    assert updated_atoms.info['change'] == "relax"
+
 def test_update_uuid_lineage_independence(atoms):
     """Test that lineage list is not shared between parent and child."""
     original_lineage = ["ancestor"]

--- a/tests/uuid/test_lineage.py
+++ b/tests/uuid/test_lineage.py
@@ -43,6 +43,11 @@ def test_full_workflow_lineage():
     assert s3.info.get("seed") == uuid1
     assert s3.info["lineage"] == [uuid1, uuid_after_rattle, uuid2]
 
+
+def test_pyxtal_records_change():
+    s = pyxtal(1, species=["Cu"], num_ions=[2])
+    assert s.info["change"] == "pyxtal"
+
 def test_individual_perturbations():
     s = Atoms("Cu2", positions=[[0,0,0], [1,1,1]], cell=[3,3,3], pbc=True)
     s.info["uuid"] = "initial-uuid"


### PR DESCRIPTION
Closes #90.

## What

`update_uuid` gains an optional `change: str | None = None` parameter. When given, it is stored under the `change` key of `structure.info`, mirroring how `uuid` always holds the *current* value rather than an accumulated history.

Wired into the call sites that previously tagged nothing:

- `Relax.relax` sets `change=type(self).__name__` (e.g. `"VolumeRelax"`).
- `pyxtal()` sets `change="pyxtal"`.
- `PerturbationABC.__call__` now derives its existing `perturbation`-key bookkeeping through the same parameter (`change=str(self)`), so a structure's `change` key always reflects the single most recent step, while the pre-existing `perturbation` key keeps its cumulative `"+"`-joined behavior for a `Series` unchanged.

## Design notes

- `change` is intentionally last-write-wins (not a list), consistent with `uuid`'s semantics: the full history is already available via `lineage`.
- No new tracking of "what changed" is layered onto the `perturbation` key's existing cumulative concatenation — that mechanism and its tests are untouched.
- Docs (`docs/metadata.rst`, `docs/lineage.rst`) updated to describe the new key.

## Testing

- New unit tests: `tests/test_utils.py` (default `None` is a no-op, single change recorded, later call overwrites), `tests/test_relax.py` (base and subclass relaxations record their class name), `tests/test_perturbations.py` (a single perturbation and a `Series` — checking `change` holds only the last step while `perturbation` stays cumulative), `tests/uuid/test_lineage.py` (`pyxtal()` records `"pyxtal"`).
- Full suite: `pytest tests/` → 180 passed, 12 skipped (skips pre-exist, unrelated to this change).
- `ruff check` on touched files: no new findings (7 pre-existing findings elsewhere in the repo, none on lines touched by this change).

---
_Generated by [Claude Code](https://claude.ai/code/session_019A5qVzmmk4zaGnyb7MNyGS)_