### PR TITLE
workflow: record the step each structure came from

### DIFF
--- a/assyst/crystals.py
+++ b/assyst/crystals.py
@@ -8,7 +8,7 @@ from typing import Self, Iterable, Iterator, Literal, overload, Union
 
 import numpy as np
 from .filters import DistanceFilter
-from .utils import update_uuid
+from .utils import record_stage, update_uuid
 
 from ase import Atoms
 from pyxtal import pyxtal as _pyxtal
@@ -117,6 +117,7 @@ def pyxtal(
                 return None
         s = s.to_ase()
         update_uuid(s)
+        record_stage(s, "spg")
         s.wrap(center=(0, 0, 0))
         return s
 

--- a/assyst/perturbations.py
+++ b/assyst/perturbations.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 import numpy as np
 
 from .filters import Filter
-from .utils import update_uuid
+from .utils import record_stage, update_uuid
 
 
 def rattle(
@@ -130,6 +130,7 @@ class PerturbationABC(ABC):
 
     def __call__(self, structure: Atoms) -> Atoms:
         update_uuid(structure)
+        record_stage(structure, str(self))
         if "perturbation" not in structure.info:
             structure.info["perturbation"] = str(self)
         else:

--- a/assyst/relaxations.py
+++ b/assyst/relaxations.py
@@ -27,6 +27,9 @@ class Relax:
     force_tolerance: float = 1e-3
     algorithm: Literal["LBFGS", "BFGS", "FIRE"] = "LBFGS"
 
+    stage_name = "relax"
+    """Name of this kind of relaxation in the stage history of a structure."""
+
     def apply_filter_and_constraints(self, structure: Atoms):
         """Hook to allow subclasses to add filters and constraints."""
         return structure
@@ -34,9 +37,11 @@ class Relax:
     def __str__(self) -> str:
         """Name of this relaxation in the stage history of a structure.
 
-        Names the kind of relaxation only; the numerical settings are not part of it.
+        Names the kind of relaxation, plus the pressure it relaxes against where that is not zero, as in
+        ``full_relax(pressure=3.0)``.  The settings of the optimizer are not part of it.
         """
-        return "relax"
+        pressure = getattr(self, "pressure", 0.0)
+        return f"{self.stage_name}(pressure={pressure})" if pressure else self.stage_name
 
     def relax(self, structure: Atoms) -> Atoms:
         """Relax a structure and return result.
@@ -83,12 +88,11 @@ class Relax:
 class CellRelax(Relax):
     """Minimize energy while keeping relative positions and volume constant."""
 
+    stage_name = "cell_relax"
+
     def apply_filter_and_constraints(self, structure: Atoms):
         structure.set_constraint(FixAtoms(np.ones(len(structure), dtype=bool)))
         return FrechetCellFilter(structure, constant_volume=True)
-
-    def __str__(self) -> str:
-        return "cell_relax"
 
 
 @dataclass(frozen=True, eq=True)
@@ -97,14 +101,13 @@ class VolumeRelax(Relax):
 
     pressure: float = 0.0
 
+    stage_name = "volume_relax"
+
     def apply_filter_and_constraints(self, structure: Atoms):
         structure.set_constraint(FixAtoms(np.ones(len(structure), dtype=bool)))
         return FrechetCellFilter(
             structure, hydrostatic_strain=True, scalar_pressure=self.pressure
         )
-
-    def __str__(self) -> str:
-        return "volume_relax"
 
 
 @dataclass(frozen=True, eq=True)
@@ -113,12 +116,11 @@ class SymmetryRelax(Relax):
 
     pressure: float = 0.0
 
+    stage_name = "symmetry_relax"
+
     def apply_filter_and_constraints(self, structure: Atoms):
         structure.set_constraint(FixSymmetry(structure))
         return FrechetCellFilter(structure, scalar_pressure=self.pressure)
-
-    def __str__(self) -> str:
-        return "symmetry_relax"
 
 
 @dataclass(frozen=True, eq=True)
@@ -127,11 +129,10 @@ class FullRelax(Relax):
 
     pressure: float = 0.0
 
+    stage_name = "full_relax"
+
     def apply_filter_and_constraints(self, structure: Atoms):
         return FrechetCellFilter(structure, scalar_pressure=self.pressure)
-
-    def __str__(self) -> str:
-        return "full_relax"
 
 
 def relax(

--- a/assyst/relaxations.py
+++ b/assyst/relaxations.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Literal, Iterable, Iterator
 
 from .calculators import AseCalculatorConfig
-from .utils import update_uuid
+from .utils import record_stage, update_uuid
 
 from ase import Atoms
 from ase.calculators.calculator import Calculator
@@ -31,11 +31,19 @@ class Relax:
         """Hook to allow subclasses to add filters and constraints."""
         return structure
 
+    def __str__(self) -> str:
+        """Name of this relaxation in the stage history of a structure.
+
+        Names the kind of relaxation only; the numerical settings are not part of it.
+        """
+        return "relax"
+
     def relax(self, structure: Atoms) -> Atoms:
         """Relax a structure and return result.
 
         Structure must have a calculator attached.
         Returned structure will have a SinglePointCalculator with the final energy, forces and stresses attached.
+        The name of this relaxation is appended to the stage history of the structure, see :func:`.record_stage`.
 
         Args:
             structure (:class:`ase.Atoms`): structure to relax
@@ -46,6 +54,7 @@ class Relax:
         calc = structure.calc
         structure = structure.copy()
         update_uuid(structure)
+        record_stage(structure, str(self))
         structure.calc = calc
         optimizer_cls = {"LBFGS": LBFGS, "BFGS": BFGS, "FIRE": FIRE}[self.algorithm]
         optimizer = optimizer_cls(self.apply_filter_and_constraints(structure), logfile="/dev/null")
@@ -78,6 +87,9 @@ class CellRelax(Relax):
         structure.set_constraint(FixAtoms(np.ones(len(structure), dtype=bool)))
         return FrechetCellFilter(structure, constant_volume=True)
 
+    def __str__(self) -> str:
+        return "cell_relax"
+
 
 @dataclass(frozen=True, eq=True)
 class VolumeRelax(Relax):
@@ -91,6 +103,9 @@ class VolumeRelax(Relax):
             structure, hydrostatic_strain=True, scalar_pressure=self.pressure
         )
 
+    def __str__(self) -> str:
+        return "volume_relax"
+
 
 @dataclass(frozen=True, eq=True)
 class SymmetryRelax(Relax):
@@ -102,6 +117,9 @@ class SymmetryRelax(Relax):
         structure.set_constraint(FixSymmetry(structure))
         return FrechetCellFilter(structure, scalar_pressure=self.pressure)
 
+    def __str__(self) -> str:
+        return "symmetry_relax"
+
 
 @dataclass(frozen=True, eq=True)
 class FullRelax(Relax):
@@ -111,6 +129,9 @@ class FullRelax(Relax):
 
     def apply_filter_and_constraints(self, structure: Atoms):
         return FrechetCellFilter(structure, scalar_pressure=self.pressure)
+
+    def __str__(self) -> str:
+        return "full_relax"
 
 
 def relax(

--- a/assyst/utils.py
+++ b/assyst/utils.py
@@ -1,6 +1,43 @@
 import uuid
 from ase import Atoms
 
+STAGE_KEY = "stage"
+"""Key in :attr:`ase.Atoms.info` under which the workflow steps a structure went through are recorded."""
+
+
+def record_stage(structure: Atoms, step: str) -> Atoms:
+    """Append the name of a workflow step to the stage history of a structure.
+
+    Steps are joined with ``+`` in the order they were applied, so a structure that was generated, volume relaxed
+    and then rattled carries ``spg+volume_relax+rattle(0.05)``.
+
+    Operates INPLACE.
+
+    Args:
+        structure (:class:`ase.Atoms`): the structure to tag
+        step (:class:`str`): name of the step that just ran
+
+    Returns:
+        :class:`ase.Atoms`: the tagged structure
+    """
+    previous = structure.info.get(STAGE_KEY, "")
+    structure.info[STAGE_KEY] = f"{previous}+{step}" if previous else step
+    return structure
+
+
+def stage_of(structure: Atoms, default: str = "unknown") -> str:
+    """The workflow steps a structure went through, as recorded by :func:`.record_stage`.
+
+    Args:
+        structure (:class:`ase.Atoms`): the structure to inspect
+        default (:class:`str`): returned for structures that carry no stage, i.e. those ASSYST did not make
+
+    Returns:
+        :class:`str`: the steps joined with ``+``, e.g. ``spg+volume_relax+full_relax``
+    """
+    return str(structure.info.get(STAGE_KEY, default))
+
+
 def update_uuid(structure: Atoms) -> Atoms:
     """Updates the UUID of the structure and maintains a lineage.
 

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -10,3 +10,4 @@ assyst
    filters
    calculators
    plot
+   utils

--- a/docs/api/utils.rst
+++ b/docs/api/utils.rst
@@ -1,0 +1,9 @@
+assyst.utils
+============
+
+.. _utils:
+
+.. automodule:: assyst.utils
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/lineage.rst
+++ b/docs/lineage.rst
@@ -26,6 +26,13 @@ Relaxations
 
 Similarly, the :meth:`.Relax.relax` method generates a new UUID for the relaxed structure and updates the lineage.
 
+Stages
+~~~~~~
+
+Where the UUIDs record *which* structure a structure came from, the ``stage`` key records *what was done to it*:
+each of the steps above appends its name to it, so ``spg+volume_relax+full_relax`` is a generated structure that was
+volume relaxed and then fully relaxed.  See :doc:`metadata` for the step names.
+
 Example
 -------
 

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -32,6 +32,25 @@ When a perturbation is applied using a :class:`assyst.perturbations.Perturbation
 
 * ``perturbation``: A string description of the perturbation(s) applied (e.g., ``rattle(0.05)+stretch(hydro=0.05, shear=0.05)``). Multiple perturbations are concatenated with a ``+``.
 
+Workflow Stage
+--------------
+
+Every step of the workflow appends its name to one key, so a structure states which steps produced it and in which order.
+
+* ``stage``: The names of the steps applied so far, concatenated with a ``+`` (e.g., ``spg+volume_relax+full_relax+rattle(0.05)``).
+
+The step names are
+
+* ``spg``: generation by :func:`assyst.crystals.pyxtal`, either directly or through :func:`assyst.crystals.sample`
+* ``relax``, ``cell_relax``, ``volume_relax``, ``symmetry_relax``, ``full_relax``: the corresponding class in :mod:`assyst.relaxations`; the numerical settings of a relaxation are not part of its name
+* the string of the applied :class:`assyst.perturbations.PerturbationABC`, the same value that goes into ``perturbation``
+
+This makes the three unperturbed sets of a plain ASSYST run tell themselves apart -- the generated structures carry
+``spg``, the volume relaxed ones ``spg+volume_relax`` and the fully relaxed ones ``spg+volume_relax+full_relax`` --
+which the ``symmetry`` and ``perturbation`` keys alone cannot do.
+
+Use :func:`assyst.utils.stage_of` to read the key and :func:`assyst.utils.record_stage` to add a step of your own.
+
 .. toctree::
    :maxdepth: 1
    :hidden:

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -42,7 +42,7 @@ Every step of the workflow appends its name to one key, so a structure states wh
 The step names are
 
 * ``spg``: generation by :func:`assyst.crystals.pyxtal`, either directly or through :func:`assyst.crystals.sample`
-* ``relax``, ``cell_relax``, ``volume_relax``, ``symmetry_relax``, ``full_relax``: the corresponding class in :mod:`assyst.relaxations`; the numerical settings of a relaxation are not part of its name
+* ``relax``, ``cell_relax``, ``volume_relax``, ``symmetry_relax``, ``full_relax``: the corresponding class in :mod:`assyst.relaxations`.  A relaxation against a non-zero pressure carries it, as in ``full_relax(pressure=3.0)``, since it minimizes to a different structure; the settings of the optimizer are not part of the name
 * the string of the applied :class:`assyst.perturbations.PerturbationABC`, the same value that goes into ``perturbation``
 
 This makes the three unperturbed sets of a plain ASSYST run tell themselves apart -- the generated structures carry

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -81,9 +81,32 @@ def test_relaxation_records_its_own_name(settings, name, cu):
     assert stage_of(settings(max_steps=1).relax(cu)) == name
 
 
-def test_relaxation_name_ignores_settings():
-    """The kind of relaxation is the stage, its numerics are not."""
-    assert str(FullRelax(max_steps=5, force_tolerance=1e-1, pressure=3.0)) == str(FullRelax())
+def test_relaxation_name_ignores_optimizer_settings():
+    """How hard the optimizer works does not change what the structure is."""
+    assert str(FullRelax(max_steps=5, force_tolerance=1e-1, algorithm="FIRE")) == str(FullRelax())
+
+
+@pytest.mark.parametrize(
+    "settings, name",
+    [
+        (VolumeRelax(pressure=1.5), "volume_relax(pressure=1.5)"),
+        (SymmetryRelax(pressure=10), "symmetry_relax(pressure=10)"),
+        (FullRelax(pressure=3.0), "full_relax(pressure=3.0)"),
+        (FullRelax(pressure=-0.25), "full_relax(pressure=-0.25)"),
+    ],
+)
+def test_pressure_enters_the_name(settings, name):
+    """Relaxing against a pressure gives a different structure, so it belongs in the stage."""
+    assert str(settings) == name
+
+
+@pytest.mark.parametrize("settings", [Relax(), CellRelax(), VolumeRelax(), SymmetryRelax(), FullRelax()])
+def test_zero_or_absent_pressure_stays_out_of_the_name(settings):
+    assert "pressure" not in str(settings)
+
+
+def test_relaxation_records_its_pressure(cu):
+    assert stage_of(VolumeRelax(max_steps=1, pressure=2.0).relax(cu)) == "volume_relax(pressure=2.0)"
 
 
 def test_relaxations_accumulate(cu):

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -1,0 +1,176 @@
+"""The ``stage`` key records which workflow steps produced a structure, in the order they ran."""
+
+import pytest
+from ase import Atoms
+from ase.build import bulk
+
+from assyst.calculators import Morse
+from assyst.crystals import Formulas, pyxtal, sample
+from assyst.perturbations import Rattle, Series, Stretch, perturb, rattle
+from assyst.relaxations import CellRelax, FullRelax, Relax, SymmetryRelax, VolumeRelax, relax
+from assyst.utils import STAGE_KEY, record_stage, stage_of
+
+
+@pytest.fixture
+def cu():
+    s = bulk("Cu", cubic=True)
+    s.calc = Morse().get_calculator()
+    return s
+
+
+@pytest.fixture
+def cu2():
+    return Atoms("Cu2", positions=[[0, 0, 0], [1.5, 1.5, 1.5]], cell=[3, 3, 3], pbc=True)
+
+
+# --- record_stage / stage_of ---
+
+
+def test_record_stage_sets_key():
+    s = Atoms("H")
+    record_stage(s, "spg")
+    assert s.info[STAGE_KEY] == "spg"
+
+
+def test_record_stage_appends_in_order():
+    s = Atoms("H")
+    for step in ("spg", "volume_relax", "full_relax"):
+        record_stage(s, step)
+    assert s.info[STAGE_KEY] == "spg+volume_relax+full_relax"
+
+
+def test_record_stage_operates_inplace():
+    s = Atoms("H")
+    assert record_stage(s, "spg") is s
+
+
+def test_record_stage_repeats_the_same_step():
+    """Relaxing twice with the same settings is two steps, not one."""
+    s = Atoms("H")
+    record_stage(s, "full_relax")
+    record_stage(s, "full_relax")
+    assert s.info[STAGE_KEY] == "full_relax+full_relax"
+
+
+def test_stage_of_reads_the_key():
+    s = Atoms("H")
+    s.info[STAGE_KEY] = "spg+volume_relax"
+    assert stage_of(s) == "spg+volume_relax"
+
+
+def test_stage_of_defaults_for_foreign_structures():
+    assert stage_of(Atoms("H")) == "unknown"
+    assert stage_of(Atoms("H"), default="external") == "external"
+
+
+# --- relaxations ---
+
+
+@pytest.mark.parametrize(
+    "settings, name",
+    [
+        (Relax, "relax"),
+        (CellRelax, "cell_relax"),
+        (VolumeRelax, "volume_relax"),
+        (SymmetryRelax, "symmetry_relax"),
+        (FullRelax, "full_relax"),
+    ],
+)
+def test_relaxation_records_its_own_name(settings, name, cu):
+    assert str(settings()) == name
+    assert stage_of(settings(max_steps=1).relax(cu)) == name
+
+
+def test_relaxation_name_ignores_settings():
+    """The kind of relaxation is the stage, its numerics are not."""
+    assert str(FullRelax(max_steps=5, force_tolerance=1e-1, pressure=3.0)) == str(FullRelax())
+
+
+def test_relaxations_accumulate(cu):
+    (volmin,) = relax([cu], VolumeRelax(max_steps=1), Morse())
+    (allmin,) = relax([volmin], FullRelax(max_steps=1), Morse())
+    assert stage_of(volmin) == "volume_relax"
+    assert stage_of(allmin) == "volume_relax+full_relax"
+
+
+def test_relax_generator_records(cu):
+    (relaxed,) = relax([cu], VolumeRelax(max_steps=1), Morse())
+    assert stage_of(relaxed) == "volume_relax"
+
+
+def test_relax_does_not_tag_its_input(cu):
+    FullRelax(max_steps=1).relax(cu)
+    assert STAGE_KEY not in cu.info
+
+
+# --- perturbations ---
+
+
+def test_perturbation_records_its_name(cu2):
+    assert stage_of(Rattle(0.1)(cu2)) == "rattle(0.1)"
+
+
+def test_series_records_every_perturbation(cu2):
+    perturbed = Series((Rattle(0.1), Stretch(hydro=0.1, shear=0.1)))(cu2)
+    assert stage_of(perturbed) == "rattle(0.1)+stretch(hydro=0.1, shear=0.1)"
+
+
+def test_perturbation_stage_agrees_with_perturbation_key(cu2):
+    perturbed = (Rattle(0.1) + Stretch(hydro=0.1, shear=0.1))(cu2)
+    assert stage_of(perturbed) == perturbed.info["perturbation"]
+
+
+def test_perturbation_extends_the_relaxation_history(cu):
+    relaxed = FullRelax(max_steps=1).relax(cu)
+    (perturbed,) = perturb([relaxed], [Rattle(0.05)])
+    assert stage_of(perturbed) == "full_relax+rattle(0.05)"
+
+
+def test_bare_perturbation_function_does_not_tag(cu2):
+    """The inplace helpers are not workflow steps; only PerturbationABC records one."""
+    rattle(cu2, 0.1)
+    assert STAGE_KEY not in cu2.info
+
+
+# --- generation ---
+
+
+def test_pyxtal_tags_generated_structures():
+    assert stage_of(pyxtal(1, species=["Cu"], num_ions=[2])) == "spg"
+
+
+def test_sample_tags_generated_structures():
+    structures = list(sample(Formulas.range("Cu", 1, 3), spacegroups=[225, 194], max_atoms=2, rng=0))
+    assert len(structures) > 0
+    assert {stage_of(s) for s in structures} == {"spg"}
+
+
+# --- the plain ASSYST workflow ---
+
+
+def test_workflow_stages_are_distinguishable():
+    """The three unperturbed sets of a plain run differ only in their stage, so it has to tell them apart."""
+    calculator = Morse()
+    settings = {"max_steps": 3, "force_tolerance": 1e-2}
+
+    spg = list(sample(Formulas.range("Cu", 1, 3), spacegroups=[225, 194], max_atoms=2, rng=0))
+    volmin = list(relax(spg, VolumeRelax(**settings), calculator))
+    allmin = list(relax(volmin, FullRelax(**settings), calculator))
+    perturbed = list(
+        perturb(
+            allmin,
+            [Rattle(0.05, create_supercells=True, rng=1), Stretch(hydro=0.1, shear=0.02, rng=2)],
+        )
+    )
+    assert len(spg) > 0 and len(perturbed) > 0
+
+    assert {stage_of(s) for s in spg} == {"spg"}
+    assert {stage_of(s) for s in volmin} == {"spg+volume_relax"}
+    assert {stage_of(s) for s in allmin} == {"spg+volume_relax+full_relax"}
+    assert {stage_of(s) for s in perturbed} == {
+        "spg+volume_relax+full_relax+rattle(0.05)",
+        "spg+volume_relax+full_relax+stretch(hydro=0.1, shear=0.02)",
+    }
+
+    # what the key is for: no two of the five sets share a stage
+    assert len({stage_of(s) for s in spg + volmin + allmin + perturbed}) == 5


### PR DESCRIPTION
Split out of #151, per [this review comment](https://github.com/eisenforschung/assyst/pull/151#discussion_r3700146538).

## The gap

After a plain ASSYST run the three unperturbed sets cannot be told apart from metadata. `symmetry` says a structure was generated, `perturbation` says it was perturbed, and nothing at all says which relaxations ran — so `spg`, `volmin` and `allmin` look identical, and any per-step analysis has to track the sets by construction instead of reading them off the structures.

## The fix

Every step appends its name to `info["stage"]`, in the order it ran:

| set | `stage` |
|---|---|
| generated | `spg` |
| volume relaxed | `spg+volume_relax` |
| fully relaxed | `spg+volume_relax+full_relax` |
| perturbed | `spg+volume_relax+full_relax+rattle(0.05)` |

- `crystals.pyxtal` tags `spg`, so both it and `sample` mark what they make
- every `Relax` subclass names itself through a new `__str__` — `relax`, `cell_relax`, `volume_relax`, `symmetry_relax`, `full_relax`. A relaxation against a non-zero `pressure` carries it, as `full_relax(pressure=3.0)`, since it minimizes to a different structure; `max_steps`, `force_tolerance` and `algorithm` say how hard the optimizer tries rather than what it is aiming at, and stay out
- `PerturbationABC` appends the same string it already writes to `perturbation`; that key is untouched, so it stays the perturbation-only view

One key rather than one key per step, because a single append-only string keeps the true order: `full_relax+rattle(0.05)` and `rattle(0.05)+full_relax` are different histories, and three separate keys joined in a fixed order would report both the same way.

`utils.record_stage(structure, step)` writes and `utils.stage_of(structure)` reads it; `stage_of` returns `"unknown"` for structures ASSYST did not make. Both are the extension point for custom steps.

## Tests

`tests/test_stages.py`, 27 tests, no new dependencies: accumulation order and repeated steps; each relaxation's name, that the optimizer settings do not change it and that a non-zero pressure does; that relaxing does not tag its input and that the bare inplace `rattle`/`stretch` helpers are not steps; `stage` agreeing with `perturbation` for perturbations; `pyxtal` and `sample` tagging `spg`; and an end-to-end plain workflow asserting the five sets have five pairwise distinct stages — the thing that was not true before.

Full suite green: 223 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLniRVF4hFR2NT95ESGmwi)_