### PR TITLE
feat(perturbations): default reference lengths for element_scaled_rattle

### DIFF
--- a/assyst/perturbations.py
+++ b/assyst/perturbations.py
@@ -3,12 +3,18 @@
 import warnings
 from abc import ABC, abstractmethod
 from ase import Atoms
+from ase.data import chemical_symbols, covalent_radii
 from typing import Iterable, Callable, Self, Iterator, Union
 from dataclasses import dataclass
 import numpy as np
 
 from .filters import Filter
 from .utils import update_uuid
+
+DEFAULT_REFERENCE_LENGTHS: dict[str, float] = {
+    sym: float(radius) for sym, radius in zip(chemical_symbols[1:], covalent_radii[1:])
+}
+"""Default per-element reference length (Å) for :func:`.element_scaled_rattle`, taken from ASE's covalent radii."""
 
 
 def rattle(
@@ -38,7 +44,7 @@ def rattle(
 def element_scaled_rattle(
     structure: Atoms,
     sigma: float,
-    reference: dict[str, float],
+    reference: Union[dict[str, float], None] = None,
     rng: Union[int, np.random.Generator, None] = None,
 ) -> Atoms:
     """Randomly displace positions with gaussian noise relative to an elemental reference length.
@@ -51,7 +57,8 @@ def element_scaled_rattle(
     Args:
         structure (:class:`ase.Atoms`): structure to perturb
         sigma (:class:`float`): relative standard deviation
-        reference (:class:`dict` of :class:`str` to :class:`float`): reference length per element
+        reference (:class:`dict` of :class:`str` to :class:`float`): reference length per element; defaults to
+            :data:`.DEFAULT_REFERENCE_LENGTHS` (ASE covalent radii) when not given
         rng (:class:`int`, :class:`numpy.random.Generator`): seed or random number generator
 
     Raises:
@@ -59,6 +66,8 @@ def element_scaled_rattle(
         ValueError: if reference values are not positive
         ValueError: if reference does not contain all elements in given structure
     """
+    if reference is None:
+        reference = DEFAULT_REFERENCE_LENGTHS
     sigma = sigma * np.ones(len(structure))
     if not all(r > 0 for r in reference.values()):
         raise ValueError("Reference lengths must be strictly positive!")
@@ -221,11 +230,12 @@ class ElementScaledRattle(RngMixin, PerturbationABC):
     """Displace atoms by some amount from a normal distribution.
 
     Operates like :class:`.Rattle` but uses a standard deviation derived from the relative `sigma` and the `reference`,
-    where this reference is given by element.
+    where this reference is given by element. `reference` defaults to :data:`.DEFAULT_REFERENCE_LENGTHS` (ASE
+    covalent radii) when not given.
     """
 
     sigma: float
-    reference: dict[str, float]
+    reference: Union[dict[str, float], None] = None
     create_supercells: bool = False
     "Create minimal 2x2x2 super cells when applied to structures of only one atom."
     rng: Union[int, np.random.Generator, None] = None
@@ -324,6 +334,7 @@ class RandomChoice(RngMixin, PerturbationABC):
 __all__ = [
         "rattle",
         "element_scaled_rattle",
+        "DEFAULT_REFERENCE_LENGTHS",
         "stretch",
         "PerturbationABC",
         "Perturbation",

--- a/tests/test_perturbations.py
+++ b/tests/test_perturbations.py
@@ -7,9 +7,12 @@ from hypothesis import given, strategies as st
 import numpy as np
 from ase import Atoms
 from ase.build import bulk
-from ase.data import atomic_numbers
+from ase.data import atomic_numbers, chemical_symbols
 
-from assyst.perturbations import rattle, element_scaled_rattle, stretch, Rattle, Stretch, Series, RandomChoice, perturb
+from assyst.perturbations import (
+    rattle, element_scaled_rattle, stretch, Rattle, ElementScaledRattle, Stretch, Series, RandomChoice, perturb,
+    DEFAULT_REFERENCE_LENGTHS,
+)
 from tests.strategies.strategies import random_element_structures
 
 
@@ -240,6 +243,48 @@ def test_element_scaled_rattle_respects_element_specific_sigma(simple_structure,
                            atol=5 * element_sigma / np.sqrt(n_repeat))
         assert np.allclose(disp.var(axis=0),  element_sigma**2,
                            atol=5 * np.sqrt(2 * sigma**4 / (n_repeat - 1)))
+
+
+def test_default_reference_lengths_covers_all_elements():
+    """DEFAULT_REFERENCE_LENGTHS should give a strictly positive value for every element ASE knows about."""
+    assert set(DEFAULT_REFERENCE_LENGTHS) == set(chemical_symbols[1:])
+    assert all(v > 0 for v in DEFAULT_REFERENCE_LENGTHS.values())
+
+
+def test_default_reference_lengths_are_ase_covalent_radii():
+    """Regression pin: the table is ASE's covalent radii, not some other scale."""
+    assert DEFAULT_REFERENCE_LENGTHS["H"] == pytest.approx(0.31)
+    assert DEFAULT_REFERENCE_LENGTHS["C"] == pytest.approx(0.76)
+    assert DEFAULT_REFERENCE_LENGTHS["Au"] == pytest.approx(1.36)
+
+
+def test_element_scaled_rattle_uses_default_reference_lengths_when_omitted():
+    """Without an explicit `reference`, the per-atom sigma passed to `rattle` should use DEFAULT_REFERENCE_LENGTHS."""
+    structure = bulk("Cu") * (2, 2, 2)
+    with patch("assyst.perturbations.rattle") as mock_rattle:
+        mock_rattle.return_value = structure
+        element_scaled_rattle(structure.copy(), sigma=0.3)
+    used_sigma = mock_rattle.call_args.args[1]
+    expected = 0.3 * DEFAULT_REFERENCE_LENGTHS["Cu"] * np.ones((len(structure), 1))
+    assert np.allclose(used_sigma, expected)
+
+
+def test_element_scaled_rattle_reference_none_matches_omitted():
+    """Passing reference=None explicitly should behave identically to omitting it."""
+    structure = bulk("Fe") * (2, 2, 2)
+    out_omitted = element_scaled_rattle(structure.copy(), sigma=0.2, rng=7)
+    out_none = element_scaled_rattle(structure.copy(), sigma=0.2, reference=None, rng=7)
+    assert np.allclose(out_omitted.positions, out_none.positions)
+
+
+def test_element_scaled_rattle_class_defaults_reference():
+    """ElementScaledRattle should default `reference` to None, letting element_scaled_rattle apply its own default."""
+    structure = bulk("Fe") * (2, 2, 2)
+    perturbation = ElementScaledRattle(sigma=0.2, rng=7)
+    with patch("assyst.perturbations.element_scaled_rattle") as mock_esr:
+        mock_esr.return_value = structure
+        perturbation(structure.copy())
+    assert mock_esr.call_args.args[2] is None
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #48.

## Summary

`element_scaled_rattle`/`ElementScaledRattle` (added in #47) require a `reference: dict[str, float]` mapping element symbol to reference length, with no built-in default — every caller had to build this table themselves.

Adds `DEFAULT_REFERENCE_LENGTHS`, a `dict[str, float]` covering every element ASE knows about, built from `ase.data.covalent_radii` (keyed by `ase.data.chemical_symbols`). `reference` on both `element_scaled_rattle` and `ElementScaledRattle` now defaults to `None`, which resolves to `DEFAULT_REFERENCE_LENGTHS`. Explicitly passing a `reference` dict is unaffected.

## Changes

- `assyst/perturbations.py`: new `DEFAULT_REFERENCE_LENGTHS` constant, exported from `__all__`; `reference` param/field defaults to `None` → `DEFAULT_REFERENCE_LENGTHS`.
- `tests/test_perturbations.py`: coverage/positivity check over all elements, a regression pin on a few known covalent-radius values (H, C, Au), and functional tests that omitting `reference` (function and class) resolves to the default table.

## Test plan

- [x] `pytest tests/test_perturbations.py tests/reproducibility/test_perturbations.py tests/pickling/test_perturbations.py tests/uuid/test_lineage.py` — 44 passed
- [x] `pytest tests/` (full suite) — 183 passed, 12 skipped

---
_Generated by [Claude Code](https://claude.ai/code/session_015KCte1ZNShAAEcJeHqD7KS)_